### PR TITLE
Fix incorrect displacement with bound labels for X64

### DIFF
--- a/src/asmjit/x86/x86assembler.cpp
+++ b/src/asmjit/x86/x86assembler.cpp
@@ -3340,7 +3340,7 @@ _EmitSib:
 
       if (label->offset != -1) {
         // Bound label.
-        dispOffset += static_cast<int32_t>((intptr_t)(cursor - self->_buffer) - label->offset);
+        dispOffset += label->offset - static_cast<int32_t>((intptr_t)(cursor - self->_buffer));
         EMIT_DWORD(static_cast<int32_t>(dispOffset));
       }
       else {


### PR DESCRIPTION
When using a bound label with the x64 assembler, the displacement offset goes into the opposite direction.
