### PR TITLE
MinGW friendlyness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ option(BUILD_SHARED_LIBS "build shared/static libraries" ON)
 
 
 If(ASMJIT_EMBED)
-  Set(BUILD_SHARED_LIBS ON)
+  Set(BUILD_SHARED_LIBS OFF)
 EndIf()
 
 If(NOT CMAKE_PROJECT_NAME)


### PR DESCRIPTION
This change aims to better support MinGW:
- install targets even when building a static library (let's say I want to package it, use it from a prefix)
- use the standard cmake BUILD_SHARED_LIBS option, see
  http://www.cmake.org/cmake/help/v3.0/variable/BUILD_SHARED_LIBS.html

Regards,
xan.
