### PR TITLE
Fix Clang warning about -f-inline-functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,6 @@ If("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     -DASMJIT_DEBUG -O0)
   Set(ASMJIT_CFLAGS_REL
     -DASMJIT_RELEASE -O2
-    -finline-functions
     -fomit-frame-pointer
     -fmerge-all-constants)
 EndIf()


### PR DESCRIPTION
[Clang no longer supports `-f-inline-functions`](http://stackoverflow.com/questions/26108606/no-support-to-finline-functions-in-clang-3-5).
