### PR TITLE
fix constant in avx512 detection

### DIFF
--- a/src/asmjit/base/cpuinfo.cpp
+++ b/src/asmjit/base/cpuinfo.cpp
@@ -501,7 +501,7 @@ static void x86DetectCpuInfo(CpuInfo* cpuInfo) noexcept {
       //   XMM/YMM states need to be enabled by OS.
       // - XCR0[7:5] == 111b
       //   Upper 256-bit of ZMM0-XMM15 and ZMM16-ZMM31 need to be enabled by the OS.
-      if ((xcr0.eax & 0x00000076U) == 0x00000076U) {
+      if ((xcr0.eax & 0x000000E6U) == 0x000000E6U) {
         cpuInfo->addFeature(CpuInfo::kX86FeatureAVX512F);
 
         if (regs.ebx & 0x00020000U) cpuInfo->addFeature(CpuInfo::kX86FeatureAVX512DQ);


### PR DESCRIPTION
asmjit currently does not detect any AVX512 instruction sets on a Xeon Phi machine.
After looking into this, I noticed that the detection logic for AVX512 used an incorrect constant -- this PR fixes it.