### PR TITLE
Properly initialize allocated memory with 0 in ZoneHashBase::_rehash.

### DIFF
--- a/src/asmjit/base/zonecontainers.cpp
+++ b/src/asmjit/base/zonecontainers.cpp
@@ -159,13 +159,16 @@ void ZoneHashBase::reset(ZoneHeap* heap) noexcept {
 void ZoneHashBase::_rehash(uint32_t newCount) noexcept {
   ASMJIT_ASSERT(isInitialized());
 
+  size_t newSize = static_cast<size_t>(newCount) * sizeof(ZoneHashNode*);
+
   ZoneHashNode** oldData = _data;
-  ZoneHashNode** newData = reinterpret_cast<ZoneHashNode**>(
-    _heap->alloc(static_cast<size_t>(newCount) * sizeof(ZoneHashNode*)));
+  ZoneHashNode** newData = reinterpret_cast<ZoneHashNode**>(_heap->alloc(newSize));
 
   // We can still store nodes into the table, but it will degrade.
   if (ASMJIT_UNLIKELY(newData == nullptr))
     return;
+
+  memset(newData, 0, newSize);
 
   uint32_t i;
   uint32_t oldCount = _bucketsCount;


### PR DESCRIPTION
I had a crash with named labels if this memory area doesn't happen to already be filled with zeroes.