### PR TITLE
Clean-up

### DIFF
--- a/src/asmjit/base/codebuilder.cpp
+++ b/src/asmjit/base/codebuilder.cpp
@@ -31,11 +31,11 @@ CodeBuilder::CodeBuilder() noexcept
     _cbHeap(&_cbBaseZone),
     _cbPasses(),
     _cbLabels(),
-    _position(0),
-    _nodeFlags(0),
     _firstNode(nullptr),
     _lastNode(nullptr),
-    _cursor(nullptr) {}
+    _cursor(nullptr),
+    _position(0),
+    _nodeFlags(0) {}
 CodeBuilder::~CodeBuilder() noexcept {}
 
 // ============================================================================

--- a/src/asmjit/base/codecompiler.h
+++ b/src/asmjit/base/codecompiler.h
@@ -270,9 +270,9 @@ public:
   //! Always use `CodeCompiler::addFunc()` to create \ref CCFunc.
   ASMJIT_INLINE CCFunc(CodeBuilder* cb) noexcept
     : CBLabel(cb),
-      _exitNode(nullptr),
       _funcDetail(),
       _frameInfo(),
+      _exitNode(nullptr),
       _end(nullptr),
       _args(nullptr),
       _isFinished(false) {

--- a/src/asmjit/base/codeemitter.cpp
+++ b/src/asmjit/base/codeemitter.cpp
@@ -156,7 +156,7 @@ Error CodeEmitter::commentf(const char* fmt, ...) {
   if (_globalOptions & kOptionLoggingEnabled) {
     va_list ap;
     va_start(ap, fmt);
-    Error err = _code->_logger->logv(fmt, ap);
+    err = _code->_logger->logv(fmt, ap);
     va_end(ap);
   }
 #else

--- a/src/asmjit/base/logging.cpp
+++ b/src/asmjit/base/logging.cpp
@@ -407,7 +407,6 @@ Error Logging::formatNode(
     }
 
     case CBNode::kNodeSentinel: {
-      const CBSentinel* node = node_->as<CBSentinel>();
       ASMJIT_PROPAGATE(sb.appendString("[sentinel]"));
       break;
     }
@@ -428,7 +427,6 @@ Error Logging::formatNode(
     }
 
     case CBNode::kNodeFuncExit: {
-      const CCFuncRet* node = node_->as<CCFuncRet>();
       ASMJIT_PROPAGATE(sb.appendString("[ret]"));
       break;
     }

--- a/src/asmjit/x86/x86assembler.cpp
+++ b/src/asmjit/x86/x86assembler.cpp
@@ -518,7 +518,7 @@ Error X86Assembler::_emit(uint32_t instId, const Operand_& o0, const Operand_& o
   int32_t relOffset;             // Relative offset
   FastUInt8 relSize = 0;         // Relative size.
 
-  int64_t imVal;                 // Immediate value (must be 64-bit).
+  int64_t imVal = 0;             // Immediate value (must be 64-bit).
   FastUInt8 imLen = 0;           // Immediate length.
 
   const uint32_t kSHR_W_PP = X86Inst::kOpCode_PP_Shift - 16;

--- a/src/asmjit/x86/x86inst.cpp
+++ b/src/asmjit/x86/x86inst.cpp
@@ -3789,7 +3789,6 @@ ASMJIT_FAVOR_SIZE Error X86Inst::validate(
       // TODO: Validate base and index and combine with `combinedRegMask`.
       case Operand::kOpMem: {
         const X86Mem& m = static_cast<const X86Mem&>(op);
-        uint32_t memSize = m.getSize();
 
         uint32_t baseType = m.getBaseType();
         uint32_t indexType = m.getIndexType();

--- a/src/asmjit/x86/x86internal.cpp
+++ b/src/asmjit/x86/x86internal.cpp
@@ -274,8 +274,6 @@ ASMJIT_FAVOR_SIZE Error X86FuncArgsContext::markStackArgsReg(FuncFrameInfo& ffi)
 
 ASMJIT_FAVOR_SIZE Error X86Internal::initCallConv(CallConv& cc, uint32_t ccId) noexcept {
   const uint32_t kKindGp  = X86Reg::kKindGp;
-  const uint32_t kKindMm  = X86Reg::kKindMm;
-  const uint32_t kKindK   = X86Reg::kKindK;
   const uint32_t kKindVec = X86Reg::kKindVec;
 
   const uint32_t kAx = X86Gp::kIdAx;
@@ -986,7 +984,6 @@ ASMJIT_FAVOR_SIZE Error X86Internal::emitArgMove(X86Emitter* emitter,
 // ============================================================================
 
 ASMJIT_FAVOR_SIZE Error X86Internal::emitProlog(X86Emitter* emitter, const FuncFrameLayout& layout) {
-  uint32_t gpSize = emitter->getGpSize();
   uint32_t gpSaved = layout.getSavedRegs(X86Reg::kKindGp);
 
   X86Gp zsp = emitter->zsp();   // ESP|RSP register.

--- a/src/asmjit/x86/x86regalloc.cpp
+++ b/src/asmjit/x86/x86regalloc.cpp
@@ -869,7 +869,6 @@ static ASMJIT_INLINE void X86RAPass_intersectStateVars(X86RAPass* self, X86RASta
 
   VirtReg** dVars = dst->getListByKind(C);
   VirtReg** aVars = a->getListByKind(C);
-  VirtReg** bVars = b->getListByKind(C);
 
   X86StateCell* aCells = a->_cells;
   X86StateCell* bCells = b->_cells;
@@ -885,7 +884,6 @@ static ASMJIT_INLINE void X86RAPass_intersectStateVars(X86RAPass* self, X86RASta
     for (uint32_t physId = 0, regMask = 0x1; physId < regCount; physId++, regMask <<= 1) {
       VirtReg* dVReg = dVars[physId]; // Destination reg.
       VirtReg* aVReg = aVars[physId]; // State-a reg.
-      VirtReg* bVReg = bVars[physId]; // State-b reg.
 
       if (dVReg == aVReg) continue;
 
@@ -1816,9 +1814,6 @@ _NextGroup:
           if (vReg->_tied)
             return DebugUtils::errored(kErrorOverlappedRegs);
 
-          uint32_t aTypeId = arg.getTypeId();
-          uint32_t vTypeId = vReg->getTypeId();
-
           uint32_t aKind = X86Reg::kindOf(arg.getRegType());
           uint32_t vKind = vReg->getKind();
 
@@ -2010,7 +2005,6 @@ _NextGroup:
           if (arg.byReg()) {
             RA_MERGE(vreg, tied, 0, 0);
 
-            uint32_t argType = arg.getTypeId();
             uint32_t argClass = X86Reg::kindOf(arg.getRegType());
 
             if (vreg->getKind() == argClass) {
@@ -2040,7 +2034,6 @@ _NextGroup:
 
           const FuncDetail::Value& ret = fd.getRet(i);
           if (ret.byReg()) {
-            uint32_t retType = ret.getTypeId();
             uint32_t retKind = X86Reg::kindOf(ret.getRegType());
 
             vreg = cc()->getVirtRegById(op->getId());
@@ -3314,9 +3307,6 @@ ASMJIT_INLINE void X86CallAlloc::alloc() {
   TiedReg* tiedArray = getTiedArrayByKind(C);
   uint32_t tiedCount = getTiedCountByKind(C);
 
-  X86RAState* state = getState();
-  VirtReg** sVars = state->getListByKind(C);
-
   uint32_t i;
   bool didWork;
 
@@ -3664,11 +3654,9 @@ static Error X86RAPass_translateOperands(X86RAPass* self, Operand_* opArray, uin
 
 //! \internal
 static Error X86RAPass_prepareFuncFrame(X86RAPass* self, CCFunc* func) {
-  FuncDetail& fd = func->getDetail();
   FuncFrameInfo& ffi = func->getFrameInfo();
 
   X86RegMask& clobberedRegs = self->_clobberedRegs;
-  uint32_t gpSize = self->cc()->getGpSize();
 
   // Initialize dirty registers.
   ffi.setDirtyRegs(X86Reg::kKindGp , clobberedRegs.get(X86Reg::kKindGp ));

--- a/src/asmjit/x86/x86ssetoavxpass.cpp
+++ b/src/asmjit/x86/x86ssetoavxpass.cpp
@@ -69,7 +69,6 @@ Error X86SseToAvxPass::process(Zone* zone) noexcept {
 
       if (!(regs & kProbeMmx)) {
         // This is the common case.
-        const X86Inst::SseData& sseData = instData.getSseData();
 
         // TODO: Wait for some fixes in CBInst first.
       }


### PR DESCRIPTION
* fixed C++ ctor init list order
* removed unused variables

I've reordered the constructor initialization list for 'CodeBuilder' and 'CodeCompiler' and cleaned some (currently) unused variables due to a bunch of compiler warnings (see compile log below). Furthermore, I've set the uninitialized value of `imVal` to zero in `x86assembler.cpp`.

~~~
- Building CXX object asmjit/src/asmjit/base/codebuilder.cpp.o
asmjit/src/asmjit/base/codebuilder.cpp:35:5: warning: field '_nodeFlags' will be initialized after field
      '_firstNode' [-Wreorder]
    _nodeFlags(0),
    ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/base/codecompiler.cpp.o
In file included from asmjit/src/asmjit/base/codecompiler.cpp:16:
asmjit/src/asmjit/base/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/base/codeemitter.cpp.o
asmjit/src/asmjit/base/codeemitter.cpp:159:11: warning: unused variable 'err' [-Wunused-variable]
    Error err = _code->_logger->logv(fmt, ap);
          ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/base/logging.cpp.o
In file included from asmjit/src/asmjit/base/logging.cpp:25:
asmjit/src/asmjit/base/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
asmjit/src/asmjit/base/logging.cpp:410:25: warning: unused variable 'node' [-Wunused-variable]
      const CBSentinel* node = node_->as<CBSentinel>();
                        ^
asmjit/src/asmjit/base/logging.cpp:431:24: warning: unused variable 'node' [-Wunused-variable]
      const CCFuncRet* node = node_->as<CCFuncRet>();
                       ^
3 warnings generated.
- Building CXX object asmjit/src/asmjit/base/regalloc.cpp.o
In file included from asmjit/src/asmjit/base/regalloc.cpp:15:
In file included from asmjit/src/asmjit/base/../base/regalloc_p.h:15:
asmjit/src/asmjit/base/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/x86/x86assembler.cpp.o
asmjit/src/asmjit/x86/x86assembler.cpp:3420:7: warning: variable 'imVal' is used uninitialized whenever
      'if' condition is true [-Wsometimes-uninitialized]
  if (imLen != 0)
      ^~~~~~~~~~
asmjit/src/asmjit/x86/x86assembler.cpp:4236:42: note: uninitialized use occurs here
    uint64_t imm = static_cast<uint64_t>(imVal);
                                         ^~~~~
asmjit/src/asmjit/x86/x86assembler.cpp:3420:3: note: remove the 'if' if its condition is always false
  if (imLen != 0)
  ^~~~~~~~~~~~~~~
asmjit/src/asmjit/x86/x86assembler.cpp:521:16: note: initialize the variable 'imVal' to silence this
      warning
  int64_t imVal;                 // Immediate value (must be 64-bit).
               ^
                = 0
1 warning generated.
- Building CXX object asmjit/src/asmjit/x86/x86compiler.cpp.o
In file included from asmjit/src/asmjit/x86/x86compiler.cpp:16:
In file included from asmjit/src/asmjit/x86/../x86/x86compiler.h:15:
asmjit/src/asmjit/x86/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/x86/x86inst.cpp.o
asmjit/src/asmjit/x86/x86inst.cpp:3792:18: warning: unused variable 'memSize' [-Wunused-variable]
        uint32_t memSize = m.getSize();
                 ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/x86/x86internal.cpp.o
asmjit/src/asmjit/x86/x86internal.cpp:278:18: warning: unused variable 'kKindK' [-Wunused-variable]
  const uint32_t kKindK   = X86Reg::kKindK;
                 ^
asmjit/src/asmjit/x86/x86internal.cpp:277:18: warning: unused variable 'kKindMm' [-Wunused-variable]
  const uint32_t kKindMm  = X86Reg::kKindMm;
                 ^
asmjit/src/asmjit/x86/x86internal.cpp:989:12: warning: unused variable 'gpSize' [-Wunused-variable]
  uint32_t gpSize = emitter->getGpSize();
           ^
3 warnings generated.
- Building CXX object asmjit/src/asmjit/x86/x86logging.cpp.o
In file included from asmjit/src/asmjit/x86/x86logging.cpp:21:
asmjit/src/asmjit/x86/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
1 warning generated.
- Building CXX object asmjit/src/asmjit/x86/x86regalloc.cpp.o
In file included from asmjit/src/asmjit/x86/x86regalloc.cpp:18:
In file included from asmjit/src/asmjit/x86/../x86/x86compiler.h:15:
asmjit/src/asmjit/x86/../base/codecompiler.h:273:7: warning: field '_exitNode' will be initialized after
      field '_funcDetail' [-Wreorder]
      _exitNode(nullptr),
      ^
asmjit/src/asmjit/x86/x86regalloc.cpp:888:16: warning: unused variable 'bVReg' [-Wunused-variable]
      VirtReg* bVReg = bVars[physId]; // State-b reg.
               ^
asmjit/src/asmjit/x86/x86regalloc.cpp:1819:20: warning: unused variable 'aTypeId' [-Wunused-variable]
          uint32_t aTypeId = arg.getTypeId();
                   ^
asmjit/src/asmjit/x86/x86regalloc.cpp:1820:20: warning: unused variable 'vTypeId' [-Wunused-variable]
          uint32_t vTypeId = vReg->getTypeId();
                   ^
asmjit/src/asmjit/x86/x86regalloc.cpp:2013:22: warning: unused variable 'argType' [-Wunused-variable]
            uint32_t argType = arg.getTypeId();
                     ^
asmjit/src/asmjit/x86/x86regalloc.cpp:2043:22: warning: unused variable 'retType' [-Wunused-variable]
            uint32_t retType = ret.getTypeId();
                     ^
asmjit/src/asmjit/x86/x86regalloc.cpp:3318:13: warning: unused variable 'sVars' [-Wunused-variable]
  VirtReg** sVars = state->getListByKind(C);
            ^
asmjit/src/asmjit/x86/x86regalloc.cpp:3667:15: warning: unused variable 'fd' [-Wunused-variable]
  FuncDetail& fd = func->getDetail();
              ^
asmjit/src/asmjit/x86/x86regalloc.cpp:3671:12: warning: unused variable 'gpSize' [-Wunused-variable]
  uint32_t gpSize = self->cc()->getGpSize();
           ^
9 warnings generated.
- Building CXX object asmjit/src/asmjit/x86/x86ssetoavxpass.cpp.o
asmjit/src/asmjit/x86/x86ssetoavxpass.cpp:72:33: warning: unused variable 'sseData' [-Wunused-variable]
        const X86Inst::SseData& sseData = instData.getSseData();
                                ^
1 warning generated.
~~~
