### PR TITLE
Named labels are printed with their name, instead of L#.

### DIFF
--- a/src/asmjit/base/assembler.cpp
+++ b/src/asmjit/base/assembler.cpp
@@ -200,7 +200,10 @@ Error Assembler::bind(const Label& label) {
 #if !defined(ASMJIT_DISABLE_LOGGING)
   if (_globalOptions & kOptionLoggingEnabled) {
     StringBuilderTmp<256> sb;
-    sb.setFormat("L%u:", Operand::unpackId(label.getId()));
+    if (le->hasName())
+      sb.setFormat("%s:", le->getName());
+    else
+      sb.setFormat("L%u:", Operand::unpackId(label.getId()));
 
     size_t binSize = 0;
     if (!_code->_logger->hasOption(Logger::kOptionBinaryForm))


### PR DESCRIPTION
Fixes this behavior:
```
jmp exit_label                          ; E9........
L15:
xor eax, eax                            ; 33C0
jmp exit_label                          ; E9........

; This is exit_label
L0:

add esp, 64                             ; 83C440
pop edi                                 ; 5F
pop esi                                 ; 5E
pop ebp                                 ; 5D
pop ebx                                 ; 5B
ret                                     ; C3
```