### PR TITLE
Go to next block group after return, so it gets a pass state

### DIFF
--- a/src/asmjit/x86/x86regalloc.cpp
+++ b/src/asmjit/x86/x86regalloc.cpp
@@ -4007,6 +4007,7 @@ _NextGroup:
           else if (node_->isRet()) {
             ASMJIT_PROPAGATE(
               X86RAPass_translateRet(this, static_cast<CCFuncRet*>(node_), func->getExitNode()));
+            goto _NextGroup;
           }
           break;
         }


### PR DESCRIPTION
wasn't able to run the tests myself. Here goes, if this breaks a host of other test cases than my project exercised....