### PR TITLE
AsmJIT support for /DYNAMICBASE executables

### DIFF
--- a/src/asmjit/base/codeemitter.cpp
+++ b/src/asmjit/base/codeemitter.cpp
@@ -109,6 +109,16 @@ Error CodeEmitter::_emitOpArray(uint32_t instId, const Operand_* opArray, size_t
 }
 
 // ============================================================================
+// [asmjit::CodeEmitter - Code-Generation-Events]
+// ============================================================================
+
+void CodeEmitter::onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, std::int64_t immVal, size_t immSize)
+{
+    // Override this to have special behavior for memory immediates.
+    return;
+}
+
+// ============================================================================
 // [asmjit::CodeEmitter - Finalize]
 // ============================================================================
 

--- a/src/asmjit/base/codeemitter.cpp
+++ b/src/asmjit/base/codeemitter.cpp
@@ -112,7 +112,7 @@ Error CodeEmitter::_emitOpArray(uint32_t instId, const Operand_* opArray, size_t
 // [asmjit::CodeEmitter - Code-Generation-Events]
 // ============================================================================
 
-void CodeEmitter::onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, std::int64_t immVal, size_t immSize)
+void CodeEmitter::onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, int64_t immVal, size_t immSize)
 {
     // Override this to have special behavior for memory immediates.
     return;

--- a/src/asmjit/base/codeemitter.h
+++ b/src/asmjit/base/codeemitter.h
@@ -175,6 +175,9 @@ public:
   //! Emit instruction having operands stored in array.
   virtual Error _emitOpArray(uint32_t instId, const Operand_* opArray, size_t opCount);
 
+  //! Notification of a new memory operand.
+  virtual void onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, std::int64_t immVal, size_t immSize);
+
   //! Create a new label.
   virtual Label newLabel() = 0;
   //! Create a new named label.

--- a/src/asmjit/base/codeemitter.h
+++ b/src/asmjit/base/codeemitter.h
@@ -176,7 +176,7 @@ public:
   virtual Error _emitOpArray(uint32_t instId, const Operand_* opArray, size_t opCount);
 
   //! Notification of a new memory operand.
-  virtual void onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, std::int64_t immVal, size_t immSize);
+  virtual void onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, int64_t immVal, size_t immSize);
 
   //! Create a new label.
   virtual Label newLabel() = 0;

--- a/src/asmjit/base/operand.h
+++ b/src/asmjit/base/operand.h
@@ -182,7 +182,7 @@ struct Operand_ {
   //! Immediate operand data.
   struct ImmData {
     uint32_t signature;                  //!< Type of the operand (always \ref kOpImm) and other data.
-    uint32_t id;                         //!< Immediate id (always `0`).
+    uint32_t flags;                      //!< Immediate flags.
     UInt64 value;                        //!< Immediate value.
   };
 
@@ -1113,8 +1113,8 @@ public:
   }
 
   //! Create a new signed immediate value, assigning the value to `val`.
-  explicit Imm(int64_t val) noexcept : Operand(NoInit) {
-    _init_packed_d0_d1(kOpImm, 0);
+  explicit Imm(int64_t val, bool isMemOp = false) noexcept : Operand(NoInit) {
+    _init_packed_d0_d1(kOpImm, ( isMemOp ? 1 : 0 ));
     _imm.value.i64 = val;
   }
 
@@ -1257,6 +1257,12 @@ public:
   }
 
   ASMJIT_INLINE void truncateTo32Bits() noexcept { _imm.value.u32Hi = 0; }
+
+  // --------------------------------------------------------------------------
+  // [Memory Immediates]
+  // --------------------------------------------------------------------------
+
+  ASMJIT_INLINE bool isMemImm(void) const noexcept { return ( _imm.flags & 1 ) != 0; }
 
   // --------------------------------------------------------------------------
   // [Operator Overload]


### PR DESCRIPTION
Adds notification of memory-based immediate values in AsmJIT machine code output so that those values can be adjusted/processed, for instance adding PE relocation entries for them (abs2abs reloc). Carefully crafted so that no effect on existing code.

* Constructor change: asmjit::Imm(int64_t val, bool isMemOp = false)
If isMemOp is true then asmjit should call onEmitMemoryAbsOp for the immediate's placement in machine code
* New virtual method: CodeEmitter::onEmitMemoryAbsOp(uint32_t sectId, size_t sectOff, std::int64_t immVal, size_t immSize)
Called for any memory-based immediate values in asmjit code generation. By default this method is a no-op, but runtimes are free to subclass X86Assembler and make it do something. Example usage is spawning abs2abs relocation entries.

```
struct MightyAssembler : public asmjit::X86Assembler
{
    inline MightyAssembler( asmjit::CodeHolder *codeHolder ) : X86Assembler( codeHolder )
    {}

    void onEmitMemoryAbsOp( std::uint32_t sectIdx, size_t sectOff, std::int64_t immVal, size_t immLen ) override
    {
        // We spawn an abs2abs relocation entry.
        asmjit::CodeHolder *code = this->getCode();

        asmjit::RelocEntry *reloc = NULL;
        code->newRelocEntry( &reloc, asmjit::RelocEntry::kTypeAbsToAbs, (std::uint32_t)immLen );

        if ( reloc )
        {
            // Fill in things.
            reloc->_data = immVal;
            reloc->_sourceSectionId = sectIdx;
            reloc->_sourceOffset = sectOff;
        }
    }
};
```

I really need these changes for my PE file generator because it is impossible to fetch the location of all immediate values in machine code without.

Example usage of new AsmJIT logic can be found here: https://osdn.net/projects/pefrm-units/scm/svn/blobs/head/pefrmdllembed/src/main.cpp line 948ff

- Martin
