### PR TITLE
X86Assembler: bugfix in checking parameters of the outs instructions

### DIFF
--- a/src/asmjit/x86/x86assembler.cpp
+++ b/src/asmjit/x86/x86assembler.cpp
@@ -1667,7 +1667,7 @@ CaseX86M_GPB_MulDiv:
 
     case X86Inst::kEncodingX86Outs:
       if (isign3 == ENC_OPS2(Reg, Mem)) {
-        if (ASMJIT_UNLIKELY(o0.getId() != X86Gp::kIdDx), !x86IsImplicitMem(o1, X86Gp::kIdSi))
+        if (ASMJIT_UNLIKELY(o0.getId() != X86Gp::kIdDx || !x86IsImplicitMem(o1, X86Gp::kIdSi)))
           goto InvalidInstruction;
 
         uint32_t size = o1.getSize();


### PR DESCRIPTION
Given that both conditions here have to apply for the outs instruction to be valid, I suppose that throwing away the result of the first check was not intended.