### PR TITLE
add TypeIdOf<bool> partial template overload

### DIFF
--- a/src/asmjit/base/operand.h
+++ b/src/asmjit/base/operand.h
@@ -1524,6 +1524,7 @@ ASMJIT_DEFINE_TYPE_ID(unsigned __int64  , TypeIdOfInt< unsigned __int64   >::kTy
 ASMJIT_DEFINE_TYPE_ID(long long         , TypeIdOfInt< long long          >::kTypeId);
 ASMJIT_DEFINE_TYPE_ID(unsigned long long, TypeIdOfInt< unsigned long long >::kTypeId);
 #endif
+ASMJIT_DEFINE_TYPE_ID(bool              , TypeIdOfInt< bool               >::kTypeId);
 #if ASMJIT_CC_HAS_NATIVE_CHAR
 ASMJIT_DEFINE_TYPE_ID(char              , TypeIdOfInt< char               >::kTypeId);
 #endif


### PR DESCRIPTION
It's currently impossible to use ``FuncSignature`` with boolean arguments due to a missing partial template overload fixed by this PR. I intentionally did not include guards (e.g. ``ASMJIT_CC_HAS_NATIVE_BOOL``) because the presence and distinctness of this type is mandated by the C++ language specification.