### PR TITLE
Fix strange method of obtaining rbp in x86 code generation

### DIFF
--- a/src/asmjit/x86/x86internal.cpp
+++ b/src/asmjit/x86/x86internal.cpp
@@ -1027,8 +1027,7 @@ ASMJIT_FAVOR_SIZE Error X86Internal::emitProlog(X86Emitter* emitter, const FuncF
   uint32_t gpSaved = layout.getSavedRegs(X86Reg::kKindGp);
 
   X86Gp zsp = emitter->zsp();   // ESP|RSP register.
-  X86Gp zbp = emitter->zsp();   // EBP|RBP register.
-  zbp.setId(X86Gp::kIdBp);
+  X86Gp zbp = emitter->zbp();   // EBP|RBP register.
 
   X86Gp gpReg = emitter->zsp(); // General purpose register (temporary).
   X86Gp saReg = emitter->zsp(); // Stack-arguments base register.
@@ -1100,8 +1099,7 @@ ASMJIT_FAVOR_SIZE Error X86Internal::emitEpilog(X86Emitter* emitter, const FuncF
   uint32_t gpSaved = layout.getSavedRegs(X86Reg::kKindGp);
 
   X86Gp zsp = emitter->zsp();   // ESP|RSP register.
-  X86Gp zbp = emitter->zsp();   // EBP|RBP register.
-  zbp.setId(X86Gp::kIdBp);
+  X86Gp zbp = emitter->zbp();   // EBP|RBP register.
 
   X86Gp gpReg = emitter->zsp(); // General purpose register (temporary).
 


### PR DESCRIPTION
Came across an odd method of obtaining a reference to the *bp register in the x86 prolog/epilog generation and modified it to be more consistent.