### PR TITLE
WIP: added initial support for perf record

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,8 @@ cxx_add_source(asmjit ASMJIT_SRC asmjit/core
   intutils.h
   jitallocator.cpp
   jitallocator.h
+  jitdump.cpp
+  jitdump.h
   jitruntime.cpp
   jitruntime.h
   jitutils.cpp

--- a/src/asmjit/core.h
+++ b/src/asmjit/core.h
@@ -26,6 +26,7 @@
 #include "./core/inst.h"
 #include "./core/intutils.h"
 #include "./core/jitallocator.h"
+#include "./core/jitdump.h"
 #include "./core/jitruntime.h"
 #include "./core/jitutils.h"
 #include "./core/logging.h"

--- a/src/asmjit/core/jitdump.cpp
+++ b/src/asmjit/core/jitdump.cpp
@@ -1,0 +1,67 @@
+#include "jitdump.h"
+
+#include <cstring>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <time.h>
+
+
+namespace asmjit{
+
+uint64_t JitDump::getTimestamp() const{
+	timespec tp;
+	clock_gettime(CLOCK_MONOTONIC, &tp); //FIXME: error handling
+	return (uint64_t)tp.tv_sec * 1'000'000'000 + tp.tv_nsec;
+}
+
+void JitDump::init(){
+	header head;
+	head.total_size = sizeof(header);
+	head.pid = getpid();
+	head.timestamp = getTimestamp();
+
+	char namebuf[1024];
+	snprintf(namebuf, sizeof(namebuf), "jit-%d.dump", head.pid);
+	int fdi = open(namebuf, O_CREAT | O_TRUNC | O_RDWR, 0666); //FIXME: error handling
+	page_size = sysconf(_SC_PAGESIZE);
+	// let perf record know about the jitdump file
+	marker = mmap(nullptr, page_size, PROT_READ | PROT_EXEC, MAP_PRIVATE, fdi, 0);
+	//if(marker_addr == MAP_FAILED) return -1; //FIXME: throw exception
+	fd = fdopen(fdi, "wb"); //FIXME: error handling
+
+	// write file header
+	fwrite(&head, sizeof(header), 1, fd);
+}
+
+void JitDump::close(){
+	munmap(marker, page_size);
+	fclose(fd);
+}
+
+void JitDump::addCodeSegment(const char *fn_name, void *fn, uint64_t code_size){
+	size_t name_len = strlen(fn_name);
+	record_header rh;
+	rh.id = JIT_CODE_LOAD;
+	rh.total_size = sizeof(record_header) + sizeof(record_load) + name_len+1 + code_size;
+	rh.timestamp = getTimestamp();
+
+	record_load rl;
+	rl.pid = getpid();
+	rl.tid = rl.pid; //FIXME: use pthread_self() to support multi-threaded applications
+	rl.vma = (uint64_t)fn;
+	rl.code_addr = rl.vma;
+	rl.code_size = code_size;
+	rl.code_index = nextid++;
+
+	// write records
+	fwrite(&rh, sizeof(record_header), 1, fd);
+	fwrite(&rl, sizeof(record_load), 1, fd);
+	fwrite(fn_name, name_len+1, 1, fd);
+	fwrite(fn, code_size, 1, fd);
+}
+
+
+}

--- a/src/asmjit/core/jitdump.h
+++ b/src/asmjit/core/jitdump.h
@@ -1,0 +1,99 @@
+#ifndef JITDUMP_HPP_
+#define JITDUMP_HPP_
+
+#include <cstdio>
+#include <cstdint>
+
+#include <elf.h>
+//#include <fcntl.h>
+//#include <sys/types.h>
+//#include <sys/mman.h>
+//#include <unistd.h>
+//#include <time.h>
+
+
+namespace asmjit{
+
+#define JITDUMP_MAGIC 0x4a695444
+//#define JITDUMP_MAGIC 0x4454694a
+
+struct header{
+	// "JiTD"
+	uint32_t magic = JITDUMP_MAGIC; //FIXME: change if architecture is big-endian
+	// 2
+	uint32_t version = 1; //FIXME: spec says 2???
+	// size in bytes of file header //FIXME: header is fixed-size, what is this?
+	uint32_t total_size;
+	// ELF architecture encoding, see /usr/include/elf.h, x86_64 == EM_X86_64
+	uint32_t elf_mach = EM_X86_64; //FIXME: hardcoded architecture
+	// padding
+	uint32_t pad1 = 0;
+	// JIT runtime pid
+	uint32_t pid;
+	// timestamp of when the file was created
+	uint64_t timestamp;
+	// bitmask of flags
+	uint64_t flags = 0;
+};
+
+
+// flags
+#define JITDUMP_FLAGS_ARCH_TIMESTAMP 0x1
+
+struct record_header{
+	// record type
+	uint32_t id;
+	// size in bytes of record including header
+	uint32_t total_size;
+	// creation timestamp of record
+	uint64_t timestamp;
+};
+
+// record type
+enum record_type{
+	JIT_CODE_LOAD           = 0, // describing a jitted function
+	JIT_CODE_MOVE           = 1, // already jitted function which is moved
+	JIT_CODE_DEBUG_INFO     = 2, // debug info for function
+	JIT_CODE_CLOSE          = 3, // end of jit runtime marker (optional)
+	JIT_CODE_UNWINDING_INFO = 4  // unwinding info for a function
+};
+
+struct record_load{
+	uint32_t pid;
+	uint32_t tid;
+	// virtual addess of jitted code start
+	uint64_t vma;
+	// code start address, default: vma == code_addr
+	uint64_t code_addr;
+	// size in bytes of jitted code
+	uint64_t code_size;
+	// unique identifier
+	uint64_t code_index;
+
+	// function name, null-terminated string
+	// native code
+};
+
+//TODO: other record types
+
+
+class JitDump{
+private:
+	uint32_t nextid=0;
+	FILE *fd;
+	void *marker;
+	long page_size;
+
+	uint64_t getTimestamp() const;
+
+public:
+	//TODO: change to ctor and dtor
+	void init();
+	void close();
+
+	void addCodeSegment(const char *fn_name, void *fn, uint64_t code_size);
+};
+
+}
+
+#endif

--- a/src/asmjit/core/jitdump.h
+++ b/src/asmjit/core/jitdump.h
@@ -1,15 +1,13 @@
 #ifndef JITDUMP_HPP_
 #define JITDUMP_HPP_
 
+
+#ifdef __linux__
+
 #include <cstdio>
 #include <cstdint>
 
 #include <elf.h>
-//#include <fcntl.h>
-//#include <sys/types.h>
-//#include <sys/mman.h>
-//#include <unistd.h>
-//#include <time.h>
 
 
 namespace asmjit{
@@ -87,13 +85,15 @@ private:
 	uint64_t getTimestamp() const;
 
 public:
-	//TODO: change to ctor and dtor
-	void init();
+	int init();
 	void close();
 
+	// dump function with associated function name
 	void addCodeSegment(const char *fn_name, void *fn, uint64_t code_size);
 };
 
 }
+
+#endif // __linux__
 
 #endif


### PR DESCRIPTION
The profiling tool perf on linux can annotate assembly code with profiling
information. This can be done for jit code as well if the jit runtime dumps
the generated code into a special file format. The added class JitDump adds
support for this file format.

Usage in application:
- create JitDump object right after JitRuntime and call init() method
- when assembling a function get the code size from CodeHolder::codeSize()
- before calling function, dump it with addCodeSegment(name, function_ptr, code_size)
- call close() at the end

Profiling steps:
- perf record -k 1 ./application
- perf inject -j -i perf.data -o perf.data.jitted
- perf report -i perf.data.jitted

In perf report the generated function should appear with the associated name.
The annotated view can be reached by pressing 'a'.