### PR TITLE
fix gcc 8 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(NOT ASMJIT_EMBED)
       "${ASMJIT_PRIVATE_CFLAGS_REL}")
 
     foreach(_target asmjit_bench_x86 asmjit_test_opcode asmjit_test_x86_asm asmjit_test_x86_cc)
-      cxx_add_executable(asmjit ${_target} "test/${_target}.cpp" "${ASMJIT_LIBS}" "${ASMJIT_CFLAGS}" "" "")
+      cxx_add_executable(asmjit ${_target} "test/${_target}.cpp" "${ASMJIT_LIBS}" "${ASMJIT_CFLAGS};${ASMJIT_PRIVATE_CFLAGS}" "" "")
     endforeach()
   endif()
 endif()

--- a/src/asmjit/base/arch.h
+++ b/src/asmjit/base/arch.h
@@ -86,7 +86,7 @@ public:
   // --------------------------------------------------------------------------
 
   ASMJIT_INLINE ArchInfo() noexcept : _signature(0) {}
-  ASMJIT_INLINE ArchInfo(const ArchInfo& other) noexcept : _signature(other._signature) {}
+  ASMJIT_INLINE ArchInfo(const ArchInfo& other) noexcept = default;
   explicit ASMJIT_INLINE ArchInfo(uint32_t type, uint32_t subType = kSubTypeNone) noexcept { init(type, subType); }
 
   ASMJIT_INLINE static ArchInfo host() noexcept { return ArchInfo(kTypeHost, kSubTypeHost); }
@@ -147,7 +147,7 @@ public:
   // [Operator Overload]
   // --------------------------------------------------------------------------
 
-  ASMJIT_INLINE const ArchInfo& operator=(const ArchInfo& other) noexcept { _signature = other._signature; return *this; }
+  ASMJIT_INLINE ArchInfo& operator=(const ArchInfo& other) noexcept = default;
   ASMJIT_INLINE bool operator==(const ArchInfo& other) const noexcept { return _signature == other._signature; }
   ASMJIT_INLINE bool operator!=(const ArchInfo& other) const noexcept { return _signature != other._signature; }
 

--- a/src/asmjit/base/cpuinfo.h
+++ b/src/asmjit/base/cpuinfo.h
@@ -37,15 +37,15 @@ public:
   // [Construction / Destruction]
   // --------------------------------------------------------------------------
 
-  ASMJIT_INLINE CpuFeatures() noexcept { reset(); }
-  ASMJIT_INLINE CpuFeatures(const CpuFeatures& other) noexcept { init(other); }
+  ASMJIT_INLINE CpuFeatures() noexcept = default;
+  ASMJIT_INLINE CpuFeatures(const CpuFeatures& other) noexcept = default;
 
   // --------------------------------------------------------------------------
   // [Init / Reset]
   // --------------------------------------------------------------------------
 
-  ASMJIT_INLINE void init(const CpuFeatures& other) noexcept { ::memcpy(this, &other, sizeof(*this)); }
-  ASMJIT_INLINE void reset() noexcept { ::memset(this, 0, sizeof(*this)); }
+  ASMJIT_INLINE void init(const CpuFeatures& other) noexcept { *this=other; }
+  ASMJIT_INLINE void reset() noexcept { *this={}; }
 
   // --------------------------------------------------------------------------
   // [Ops]
@@ -100,7 +100,7 @@ public:
   // [Members]
   // --------------------------------------------------------------------------
 
-  BitWord _bits[kNumBitWords];
+  BitWord _bits[kNumBitWords] = {0};
 };
 
 // ============================================================================
@@ -238,18 +238,18 @@ public:
   // --------------------------------------------------------------------------
 
   struct X86Data {
-    uint32_t _processorType;             //!< Processor type.
-    uint32_t _brandIndex;                //!< Brand index.
-    uint32_t _flushCacheLineSize;        //!< Flush cache line size (in bytes).
-    uint32_t _maxLogicalProcessors;      //!< Maximum number of addressable IDs for logical processors.
+    uint32_t _processorType = 0;         //!< Processor type.
+    uint32_t _brandIndex = 0;            //!< Brand index.
+    uint32_t _flushCacheLineSize = 0;    //!< Flush cache line size (in bytes).
+    uint32_t _maxLogicalProcessors = 0;  //!< Maximum number of addressable IDs for logical processors.
   };
 
   // --------------------------------------------------------------------------
   // [Construction / Destruction]
   // --------------------------------------------------------------------------
 
-  ASMJIT_INLINE CpuInfo() noexcept { reset(); }
-  ASMJIT_INLINE CpuInfo(const CpuInfo& other) noexcept { init(other); }
+  ASMJIT_INLINE CpuInfo() noexcept : _x86Data({}) {}
+  ASMJIT_INLINE CpuInfo(const CpuInfo& other) noexcept = default;
 
   // --------------------------------------------------------------------------
   // [Init / Reset]
@@ -260,8 +260,8 @@ public:
     _archInfo.init(archType, archMode);
   }
 
-  ASMJIT_INLINE void init(const CpuInfo& other) noexcept { ::memcpy(this, &other, sizeof(*this)); }
-  ASMJIT_INLINE void reset() noexcept { ::memset(this, 0, sizeof(*this)); }
+  ASMJIT_INLINE void init(const CpuInfo& other) noexcept { *this = other; }
+  ASMJIT_INLINE void reset() noexcept { *this = {}; }
 
   // --------------------------------------------------------------------------
   // [Detect]
@@ -346,14 +346,14 @@ public:
   // --------------------------------------------------------------------------
 
   ArchInfo _archInfo;                    //!< CPU architecture information.
-  uint32_t _vendorId;                    //!< CPU vendor id, see \ref Vendor.
-  uint32_t _family;                      //!< CPU family ID.
-  uint32_t _model;                       //!< CPU model ID.
-  uint32_t _stepping;                    //!< CPU stepping.
-  uint32_t _hwThreadsCount;              //!< Number of hardware threads.
+  uint32_t _vendorId = 0;                //!< CPU vendor id, see \ref Vendor.
+  uint32_t _family = 0;                  //!< CPU family ID.
+  uint32_t _model = 0;                   //!< CPU model ID.
+  uint32_t _stepping = 0;                //!< CPU stepping.
+  uint32_t _hwThreadsCount = 0;          //!< Number of hardware threads.
   CpuFeatures _features;                 //!< CPU features.
-  char _vendorString[16];                //!< CPU vendor string.
-  char _brandString[64];                 //!< CPU brand string.
+  char _vendorString[16] = {0};          //!< CPU vendor string.
+  char _brandString[64] = {0};           //!< CPU brand string.
 
   // Architecture specific data.
   union {

--- a/src/asmjit/base/operand.h
+++ b/src/asmjit/base/operand.h
@@ -1505,6 +1505,14 @@ struct TypeIdOfInt {
   };
 };
 
+template<>
+struct TypeIdOfInt<bool> {
+  enum {
+    kSignatureed = true,
+    kTypeId = (int)(TypeId::kI8)
+  };
+};
+
 #define ASMJIT_DEFINE_TYPE_ID(T, TYPE_ID) \
   template<> \
   struct TypeIdOf<T> { enum { kTypeId = TYPE_ID}; }

--- a/src/asmjit/x86/x86builder.h
+++ b/src/asmjit/x86/x86builder.h
@@ -71,6 +71,8 @@ public:
   // [Code-Generation]
   // --------------------------------------------------------------------------
 
+  using CodeBuilder::_emit;
+
   ASMJIT_API virtual Error _emit(uint32_t instId, const Operand_& o0, const Operand_& o1, const Operand_& o2, const Operand_& o3) override;
 };
 


### PR DESCRIPTION
When including the asmjit headers in a project build with
gcc 8 and -Wall -Wextra the headers trigger several compiler warnings,
which makes them hard to use (in particular in combination with -Werror).

The main problems are memcpy/memset on non-trivial objects, hidden virtual
functions, and bit arithmetic on bool (with implicit int promotion).
This commit fixes all of them by using more idiomatic C++ constructs.