### PR TITLE
Add FuncFrame::addDirtyReg()

### DIFF
--- a/src/asmjit/core/func.h
+++ b/src/asmjit/core/func.h
@@ -674,6 +674,11 @@ public:
     _dirtyRegs[group] |= regs;
   }
 
+  //! Add a single register (by `reg`) to saved/restored registers.
+  inline void addDirtyReg(const BaseReg& reg) noexcept {
+    addDirtyRegs(reg.group(), 1u << reg.id());
+  }
+
   inline void setAllDirty() noexcept {
     _dirtyRegs[0] = 0xFFFFFFFFu;
     _dirtyRegs[1] = 0xFFFFFFFFu;

--- a/src/asmjit/core/func.h
+++ b/src/asmjit/core/func.h
@@ -676,7 +676,15 @@ public:
 
   //! Add a single register (by `reg`) to saved/restored registers.
   inline void addDirtyReg(const BaseReg& reg) noexcept {
-    addDirtyRegs(reg.group(), 1u << reg.id());
+    ASMJIT_ASSERT(reg.id() < Globals::kMaxPhysRegs);
+    addDirtyRegs(reg.group(), Support::bitMask(reg.id()));
+  }
+
+  //! Add one or more registers to saved/restored registers.
+  template<typename ...Args>
+  inline void addDirtyRegs(const BaseReg& reg, Args&&... args) noexcept {
+    addDirtyReg(reg);
+    addDirtyRegs(std::forward<Args>(args)...);
   }
 
   inline void setAllDirty() noexcept {


### PR DESCRIPTION
Simplifies slightly the use of addDirtyRegs if you have the register around.