### PR TITLE
Replace incorrect CMake CACHE variable type BOOLEAN with BOOL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,11 @@ endif()
 # =============================================================================
 
 set(ASMJIT_DIR        "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Location of 'asmjit'")
-set(ASMJIT_EMBED      ${ASMJIT_EMBED}             CACHE BOOLEAN "Embed 'asmjit' library (no targets)")
-set(ASMJIT_STATIC     ${ASMJIT_STATIC}            CACHE BOOLEAN "Build 'asmjit' library as static")
-set(ASMJIT_BUILD_ARM  ${ASMJIT_BUILD_ARM}         CACHE BOOLEAN "Build ARM32/ARM64 backends")
-set(ASMJIT_BUILD_X86  ${ASMJIT_BUILD_X86}         CACHE BOOLEAN "Build X86/X64 backends")
-set(ASMJIT_BUILD_TEST ${ASMJIT_BUILD_TEST}        CACHE BOOLEAN "Build 'asmjit_test' applications")
+set(ASMJIT_EMBED      ${ASMJIT_EMBED}             CACHE BOOL "Embed 'asmjit' library (no targets)")
+set(ASMJIT_STATIC     ${ASMJIT_STATIC}            CACHE BOOL "Build 'asmjit' library as static")
+set(ASMJIT_BUILD_ARM  ${ASMJIT_BUILD_ARM}         CACHE BOOL "Build ARM32/ARM64 backends")
+set(ASMJIT_BUILD_X86  ${ASMJIT_BUILD_X86}         CACHE BOOL "Build X86/X64 backends")
+set(ASMJIT_BUILD_TEST ${ASMJIT_BUILD_TEST}        CACHE BOOL "Build 'asmjit_test' applications")
 
 # =============================================================================
 # [AsmJit - Project]


### PR DESCRIPTION
As documented here https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry there is no CACHE type `BOOLEAN`; use the proper `BOOL` type.

CMake 3.14 generates the following warning:
```
CMake Warning (dev) at CMakeLists.txt:34 (set):
  implicitly converting 'BOOLEAN' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```