### PR TITLE
Fix CpuInfo Global Initialization Order

### DIFF
--- a/src/asmjit/core/arch.h
+++ b/src/asmjit/core/arch.h
@@ -7,6 +7,7 @@
 #ifndef _ASMJIT_CORE_ARCH_H
 #define _ASMJIT_CORE_ARCH_H
 
+#include "../core/globals.h"
 #include "../core/operand.h"
 
 ASMJIT_BEGIN_NAMESPACE
@@ -81,6 +82,7 @@ public:
   inline ArchInfo() noexcept : _signature(0) {}
   inline ArchInfo(const ArchInfo& other) noexcept : _signature(other._signature) {}
   inline explicit ArchInfo(uint32_t type, uint32_t subType = kSubIdNone) noexcept { init(type, subType); }
+  inline explicit ArchInfo(Globals::NoInit_) noexcept {}
 
   inline static ArchInfo host() noexcept { return ArchInfo(kIdHost, kSubIdHost); }
 

--- a/src/asmjit/core/cpuinfo.h
+++ b/src/asmjit/core/cpuinfo.h
@@ -9,6 +9,7 @@
 
 #include "../core/arch.h"
 #include "../core/features.h"
+#include "../core/globals.h"
 #include "../core/string.h"
 
 ASMJIT_BEGIN_NAMESPACE
@@ -29,7 +30,8 @@ public:
 
   inline CpuInfo() noexcept { reset(); }
   inline CpuInfo(const CpuInfo& other) noexcept = default;
-  inline explicit CpuInfo(Globals::NoInit_) noexcept {};
+  inline explicit CpuInfo(Globals::NoInit_) noexcept
+    : _archInfo(Globals::NoInit), _features(Globals::NoInit) {};
 
   // --------------------------------------------------------------------------
   // [Init / Reset]

--- a/src/asmjit/core/features.h
+++ b/src/asmjit/core/features.h
@@ -7,6 +7,7 @@
 #ifndef _ASMJIT_CORE_FEATURES_H
 #define _ASMJIT_CORE_FEATURES_H
 
+#include "../core/globals.h"
 #include "../core/support.h"
 
 ASMJIT_BEGIN_NAMESPACE
@@ -33,6 +34,7 @@ public:
 
   inline BaseFeatures() noexcept { reset(); }
   inline BaseFeatures(const BaseFeatures& other) noexcept = default;
+  inline explicit BaseFeatures(Globals::NoInit_) noexcept {}
 
   // --------------------------------------------------------------------------
   // [Reset]


### PR DESCRIPTION
If I have a global `JitRuntime`, its constructor (which calls `CpuInfo::host()`) can be called before `cpuInfoGlobal`'s `Globals::NoInit` constructor which in turn calls the normal `cpuInfoGlobal._archInfo` and `cpuInfoGlobal._features` constructors which clobber the information already stored there.  Fix by propagating the `Globals::NoInit` flag.