### PR TITLE
Fix Undefined Reference to Static Members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,7 @@ set(ASMJIT_SRC_LIST
   asmjit/x86/x86emitter.h
   asmjit/x86/x86features.cpp
   asmjit/x86/x86features.h
+  asmjit/x86/x86globals.cpp
   asmjit/x86/x86globals.h
   asmjit/x86/x86internal.cpp
   asmjit/x86/x86internal_p.h

--- a/src/asmjit/x86/x86globals.cpp
+++ b/src/asmjit/x86/x86globals.cpp
@@ -1,0 +1,27 @@
+// [AsmJit]
+// Machine Code Generation for C++.
+//
+// [License]
+// ZLIB - See LICENSE.md file in the package.
+
+#define ASMJIT_EXPORTS
+
+#include "../core/build.h"
+#if defined(ASMJIT_BUILD_X86) && ASMJIT_ARCH_X86
+
+#include "../x86/x86globals.h"
+
+ASMJIT_BEGIN_SUB_NAMESPACE(x86)
+
+// ============================================================================
+// [asmjit::x86::Inst]
+// ============================================================================
+
+//! Definitions for Inst static members.
+constexpr uint16_t Inst::jccTable[];
+constexpr uint16_t Inst::setccTable[];
+constexpr uint16_t Inst::cmovccTable[];
+
+ASMJIT_END_SUB_NAMESPACE
+
+#endif // ASMJIT_BUILD_X86 && ASMJIT_ARCH_X86


### PR DESCRIPTION
`static` has a different meaning inside a `namespace` versus inside a `class`, and (at least in C++11) `static` members always require a definition.  In this case, no initializers are needed in the definitions because they already exist in the `constexpr` declarations.