### PR TITLE
Detach X86Assembler from CodeHolder in destructing

### DIFF
--- a/src/asmjit/x86/x86assembler.cpp
+++ b/src/asmjit/x86/x86assembler.cpp
@@ -481,7 +481,10 @@ Assembler::Assembler(CodeHolder* code) noexcept : BaseAssembler() {
   if (code)
     code->attach(this);
 }
-Assembler::~Assembler() noexcept {}
+Assembler::~Assembler() noexcept {
+  if (_codeHolder)
+    _codeHolder->detach(this);
+}
 
 // ============================================================================
 // [asmjit::x86::Assembler - Emit (Low-Level)]

--- a/src/asmjit/x86/x86assembler.h
+++ b/src/asmjit/x86/x86assembler.h
@@ -30,6 +30,9 @@ public:
   ASMJIT_NONCOPYABLE(Assembler)
   typedef BaseAssembler Base;
 
+  //! Attachted code holder
+  CodeHolder* _codeHolder;
+
   //! \name Construction & Destruction
   //! \{
 


### PR DESCRIPTION
Hello,

In constructing an `x86Assembler`, it may be attached in a `CodeHolder`
https://github.com/asmjit/asmjit/blob/238243530a35f5ad6205695ff0267b8bd639543a/src/asmjit/x86/x86assembler.cpp#L480-L483

and the assembler is added into https://github.com/asmjit/asmjit/blob/238243530a35f5ad6205695ff0267b8bd639543a/src/asmjit/core/codeholder.cpp#L226-L228

but there is no mechanism allowing the code holder knows whether the assembler is still alive, e.g.

```C++
CodeHolder ch;
{
  x86::Assembler asm(&ch);
}
// asm is destroyed, but ch doesn't know, use-after-free?
```
Sorry if I missed something and many thank for any response.