### PR TITLE
Do not expose Windows headers through AsmJit headers

### DIFF
--- a/src/asmjit/core/build.h
+++ b/src/asmjit/core/build.h
@@ -97,22 +97,10 @@
 #include <utility>
 
 #if defined(_WIN32)
-  #ifndef WIN32_LEAN_AND_MEAN
+  #ifdef ASMJIT_EXPORTS
     #define WIN32_LEAN_AND_MEAN
-    #define ASMJIT_UNDEF_WIN32_LEAN_AND_MEAN
-  #endif
-  #ifndef NOMINMAX
     #define NOMINMAX
-    #define ASMJIT_UNDEF_NOMINMAX
-  #endif
-  #include <windows.h>
-  #ifdef ASMJIT_UNDEF_WIN32_LEAN_AND_MEAN
-    #undef WIN32_LEAN_AND_MEAN
-    #undef ASMJIT_UNDEF_WIN32_LEAN_AND_MEAN
-  #endif
-  #ifdef ASMJIT_UNDEF_NOMINMAX
-    #undef NOMINMAX
-    #undef ASMJIT_UNDEF_NOMINMAX
+    #include <windows.h>
   #endif
 #else
   #include <pthread.h>

--- a/src/asmjit/core/osutils.cpp
+++ b/src/asmjit/core/osutils.cpp
@@ -87,4 +87,16 @@ uint32_t OSUtils::getTickCount() noexcept {
 #endif
 }
 
+#if defined(_WIN32)
+
+static_assert(sizeof(Lock::Handle) >= sizeof(CRITICAL_SECTION), "Lock::Handle too small, increase size of data array");
+
+Lock::Lock() noexcept { InitializeCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(&_handle)); }
+Lock::~Lock() noexcept { DeleteCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(&_handle)); }
+
+void Lock::lock() noexcept { EnterCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(&_handle)); }
+void Lock::unlock() noexcept { LeaveCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(&_handle)); }
+
+#endif
+
 ASMJIT_END_NAMESPACE

--- a/src/asmjit/core/osutils.h
+++ b/src/asmjit/core/osutils.h
@@ -37,14 +37,14 @@ public:
 
   #if defined(_WIN32)
 
-  typedef CRITICAL_SECTION Handle;
+  typedef struct { uint32_t data[16]; } Handle; // structure must be at least as large as CRITICAL_SECTION
   Handle _handle;
 
-  inline Lock() noexcept { InitializeCriticalSection(&_handle); }
-  inline ~Lock() noexcept { DeleteCriticalSection(&_handle); }
+  Lock() noexcept;
+  ~Lock() noexcept;
 
-  inline void lock() noexcept { EnterCriticalSection(&_handle); }
-  inline void unlock() noexcept { LeaveCriticalSection(&_handle); }
+  void lock() noexcept;
+  void unlock() noexcept;
 
   #elif !defined(__EMSCRIPTEN__)
 


### PR DESCRIPTION
The Windows headers, even with `NOMINMAX` and `WIN32_LEAN_AND_MEAN` define many rather vague macros that often cause conflicts with other libraries. Unfortunately, including `asmjit.h` causes `windows.h` to be included as well, so I propose the following changes, which make sure that `windows.h` is only included in implementation files.

The only definition that had actually been used in a header was `CRITICAL_SECTION` in `asmjit::Lock`, which I have replaced with a binary array of sufficient length. A more correct solution would be to use PIMPL at a slight performance cost, but since it is just a POD structure, this should work too.