### PR TITLE
Visual Studio 2015 compatibility

### DIFF
--- a/src/asmjit/core/build.h
+++ b/src/asmjit/core/build.h
@@ -223,6 +223,8 @@
 #define ASMJIT_CXX_MSC   0
 #define ASMJIT_CXX_MAKE_VER(MAJOR, MINOR, PATCH) ((MAJOR) * 10000000 + (MINOR) * 100000 + (PATCH))
 
+#define ASMJIT_OPERAND_CONSTEXPR constexpr
+
 // Intel Compiler [pretends to be GNU or MSC, so it must be checked first]:
 //   - https://software.intel.com/en-us/articles/c0x-features-supported-by-intel-c-compiler
 //   - https://software.intel.com/en-us/articles/c14-features-supported-by-intel-c-compiler
@@ -254,7 +256,8 @@
   //         union. There is no workaround known other than rewriting the whole
   //         code. VS2017 has a similar bug, but it can be workarounded.
   #if ASMJIT_CXX_MSC < ASMJIT_CXX_MAKE_VER(19, 10, 0)
-    #error "[asmjit] At least VS2017 is required due to a severe bug in VS2015's constexpr implementation"
+    #undef ASMJIT_OPERAND_CONSTEXPR
+    #define ASMJIT_OPERAND_CONSTEXPR
   #endif
 
 // Clang Compiler [Pretends to be GNU, so it must be checked before]:

--- a/src/asmjit/core/operand.h
+++ b/src/asmjit/core/operand.h
@@ -42,19 +42,19 @@ struct RegTraits<REG_TYPE> {                                                  \
 #define ASMJIT_DEFINE_ABSTRACT_REG(REG, BASE)                                 \
 public:                                                                       \
   /*! Default constructor that only setups basics. */                         \
-  constexpr REG() noexcept                                                    \
+  ASMJIT_OPERAND_CONSTEXPR REG() noexcept                                     \
     : BASE(kSignature, kIdBad) {}                                             \
                                                                               \
   /*! Makes a copy of the `other` register operand. */                        \
-  constexpr REG(const REG& other) noexcept                                    \
+  ASMJIT_OPERAND_CONSTEXPR REG(const REG& other) noexcept                     \
     : BASE(other) {}                                                          \
                                                                               \
   /*! Makes a copy of the `other` register having id set to `rId` */          \
-  constexpr REG(const BaseReg& other, uint32_t rId) noexcept                  \
+  ASMJIT_OPERAND_CONSTEXPR REG(const BaseReg& other, uint32_t rId) noexcept   \
     : BASE(other, rId) {}                                                     \
                                                                               \
   /*! Creates a register based on `signature` and `rId`. */                   \
-  constexpr REG(uint32_t signature, uint32_t rId) noexcept                    \
+  ASMJIT_OPERAND_CONSTEXPR REG(uint32_t signature, uint32_t rId) noexcept     \
     : BASE(signature, rId) {}                                                 \
                                                                               \
   /*! Creates a completely uninitialized REG register operand (garbage). */   \
@@ -67,7 +67,7 @@ public:                                                                       \
   }                                                                           \
                                                                               \
   /*! Clones the register operand. */                                         \
-  constexpr REG clone() const noexcept { return REG(*this); }                 \
+  ASMJIT_OPERAND_CONSTEXPR REG clone() const noexcept { return REG(*this); }  \
                                                                               \
   inline REG& operator=(const REG& other) noexcept = default;
 
@@ -83,7 +83,7 @@ public:                                                                       \
   ASMJIT_DEFINE_ABSTRACT_REG(REG, BASE)                                       \
                                                                               \
   /*! Creates a register operand having its id set to `rId`. */               \
-  constexpr explicit REG(uint32_t rId) noexcept                               \
+  ASMJIT_OPERAND_CONSTEXPR explicit REG(uint32_t rId) noexcept                \
     : BASE(kSignature, rId) {}
 
 //! \addtogroup asmjit_core
@@ -273,8 +273,8 @@ struct Operand_ {
   //! \name Operator Overloads
   //! \{
 
-  constexpr bool operator==(const Operand_& other) const noexcept { return  isEqual(other); }
-  constexpr bool operator!=(const Operand_& other) const noexcept { return !isEqual(other); }
+  ASMJIT_OPERAND_CONSTEXPR bool operator==(const Operand_& other) const noexcept { return  isEqual(other); }
+  ASMJIT_OPERAND_CONSTEXPR bool operator!=(const Operand_& other) const noexcept { return !isEqual(other); }
 
   //! \}
 
@@ -295,16 +295,16 @@ struct Operand_ {
   //! \{
 
   //! Tests whether the operand matches the given signature `sign`.
-  constexpr bool hasSignature(uint32_t signature) const noexcept { return _signature == signature; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasSignature(uint32_t signature) const noexcept { return _signature == signature; }
   //! Tests whether the operand matches the signature of the `other` operand.
-  constexpr bool hasSignature(const Operand_& other) const noexcept { return _signature == other.signature(); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasSignature(const Operand_& other) const noexcept { return _signature == other.signature(); }
 
   //! Returns operand signature as unsigned 32-bit integer.
   //!
   //! Signature is first 4 bytes of the operand data. It's used mostly for
   //! operand checking as it's much faster to check 4 bytes at once than having
   //! to check these bytes individually.
-  constexpr uint32_t signature() const noexcept { return _signature; }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t signature() const noexcept { return _signature; }
 
   //! Sets the operand signature, see `signature()`.
   //!
@@ -313,12 +313,12 @@ struct Operand_ {
 
   //! \cond INTERNAL
   template<uint32_t mask>
-  constexpr bool _hasSignaturePart() const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool _hasSignaturePart() const noexcept {
     return (_signature & mask) != 0;
   }
 
   template<uint32_t mask>
-  constexpr uint32_t _getSignaturePart() const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR uint32_t _getSignaturePart() const noexcept {
     return (_signature >> Support::constCtz(mask)) & (mask >> Support::constCtz(mask));
   }
 
@@ -330,27 +330,27 @@ struct Operand_ {
   //! \endcond
 
   //! Returns the type of the operand, see `OpType`.
-  constexpr uint32_t opType() const noexcept { return _getSignaturePart<kSignatureOpMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t opType() const noexcept { return _getSignaturePart<kSignatureOpMask>(); }
   //! Tests whether the operand is none (`kOpNone`).
-  constexpr bool isNone() const noexcept { return _signature == 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool isNone() const noexcept { return _signature == 0; }
   //! Tests whether the operand is a register (`kOpReg`).
-  constexpr bool isReg() const noexcept { return opType() == kOpReg; }
+  ASMJIT_OPERAND_CONSTEXPR bool isReg() const noexcept { return opType() == kOpReg; }
   //! Tests whether the operand is a memory location (`kOpMem`).
-  constexpr bool isMem() const noexcept { return opType() == kOpMem; }
+  ASMJIT_OPERAND_CONSTEXPR bool isMem() const noexcept { return opType() == kOpMem; }
   //! Tests whether the operand is an immediate (`kOpImm`).
-  constexpr bool isImm() const noexcept { return opType() == kOpImm; }
+  ASMJIT_OPERAND_CONSTEXPR bool isImm() const noexcept { return opType() == kOpImm; }
   //! Tests whether the operand is a label (`kOpLabel`).
-  constexpr bool isLabel() const noexcept { return opType() == kOpLabel; }
+  ASMJIT_OPERAND_CONSTEXPR bool isLabel() const noexcept { return opType() == kOpLabel; }
 
   //! Tests whether the operand is a physical register.
-  constexpr bool isPhysReg() const noexcept { return isReg() && _baseId < 0xFFu; }
+  ASMJIT_OPERAND_CONSTEXPR bool isPhysReg() const noexcept { return isReg() && _baseId < 0xFFu; }
   //! Tests whether the operand is a virtual register.
-  constexpr bool isVirtReg() const noexcept { return isReg() && _baseId > 0xFFu; }
+  ASMJIT_OPERAND_CONSTEXPR bool isVirtReg() const noexcept { return isReg() && _baseId > 0xFFu; }
 
   //! Tests whether the operand specifies a size (i.e. the size is not zero).
-  constexpr bool hasSize() const noexcept { return _hasSignaturePart<kSignatureSizeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasSize() const noexcept { return _hasSignaturePart<kSignatureSizeMask>(); }
   //! Tests whether the size of the operand matches `size`.
-  constexpr bool hasSize(uint32_t s) const noexcept { return size() == s; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasSize(uint32_t s) const noexcept { return size() == s; }
 
   //! Returns the size of the operand in bytes.
   //!
@@ -363,7 +363,7 @@ struct Operand_ {
   //!   * Mem   - Size is optional and will be in most cases zero.
   //!   * Imm   - Should always return zero size.
   //!   * Label - Should always return zero size.
-  constexpr uint32_t size() const noexcept { return _getSignaturePart<kSignatureSizeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t size() const noexcept { return _getSignaturePart<kSignatureSizeMask>(); }
 
   //! Returns the operand id.
   //!
@@ -376,28 +376,28 @@ struct Operand_ {
   //!   * Label - Label id if it was created by using `newLabel()` or
   //!             `Globals::kInvalidId` if the label is invalid or not
   //!             initialized.
-  constexpr uint32_t id() const noexcept { return _baseId; }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t id() const noexcept { return _baseId; }
 
   //! Tests whether the operand is 100% equal to `other`.
-  constexpr bool isEqual(const Operand_& other) const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool isEqual(const Operand_& other) const noexcept {
     return (_signature == other._signature) &
            (_baseId    == other._baseId   ) &
            (_data64    == other._data64   ) ;
   }
 
   //! Tests whether the operand is a register matching `rType`.
-  constexpr bool isReg(uint32_t rType) const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool isReg(uint32_t rType) const noexcept {
     return (_signature & (kSignatureOpMask | kSignatureRegTypeMask)) ==
            ((kOpReg << kSignatureOpShift) | (rType << kSignatureRegTypeShift));
   }
 
   //! Tests whether the operand is register and of `rType` and `rId`.
-  constexpr bool isReg(uint32_t rType, uint32_t rId) const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool isReg(uint32_t rType, uint32_t rId) const noexcept {
     return isReg(rType) && id() == rId;
   }
 
   //! Tests whether the operand is a register or memory.
-  constexpr bool isRegOrMem() const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool isRegOrMem() const noexcept {
     return Support::isBetween<uint32_t>(opType(), kOpReg, kOpMem);
   }
 
@@ -415,18 +415,18 @@ public:
   //! \{
 
   //! Creates `kOpNone` operand having all members initialized to zero.
-  constexpr Operand() noexcept
+  ASMJIT_OPERAND_CONSTEXPR Operand() noexcept
     : Operand_{ kOpNone, 0u, {{ 0u, 0u }}} {}
 
   //! Creates a cloned `other` operand.
-  constexpr Operand(const Operand& other) noexcept = default;
+  ASMJIT_OPERAND_CONSTEXPR Operand(const Operand& other) noexcept = default;
 
   //! Creates a cloned `other` operand.
-  constexpr explicit Operand(const Operand_& other)
+  ASMJIT_OPERAND_CONSTEXPR explicit Operand(const Operand_& other)
     : Operand_(other) {}
 
   //! Creates an operand initialized to raw `[u0, u1, u2, u3]` values.
-  constexpr Operand(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Operand(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
     : Operand_{ u0, u1, {{ u2, u3 }}} {}
 
   //! Creates an uninitialized operand (dangerous).
@@ -446,7 +446,7 @@ public:
   //! \{
 
   //! Clones this operand and returns its copy.
-  constexpr Operand clone() const noexcept { return Operand(*this); }
+  ASMJIT_OPERAND_CONSTEXPR Operand clone() const noexcept { return Operand(*this); }
 
   //! \}
 };
@@ -455,7 +455,7 @@ static_assert(sizeof(Operand) == 16, "asmjit::Operand must be exactly 16 bytes l
 
 namespace Globals {
   //! A default-constructed operand of `Operand_::kOpNone` type.
-  static constexpr const Operand none;
+  static ASMJIT_OPERAND_CONSTEXPR const Operand none;
 }
 
 // ============================================================================
@@ -515,15 +515,15 @@ public:
   //! \{
 
   //! Creates a label operand without ID (you must set the ID to make it valid).
-  constexpr Label() noexcept
+  ASMJIT_OPERAND_CONSTEXPR Label() noexcept
     : Operand(Globals::Init, kOpLabel, Globals::kInvalidId, 0, 0) {}
 
   //! Creates a cloned label operand of `other` .
-  constexpr Label(const Label& other) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Label(const Label& other) noexcept
     : Operand(other) {}
 
   //! Creates a label operand of the given `id`.
-  constexpr explicit Label(uint32_t id) noexcept
+  ASMJIT_OPERAND_CONSTEXPR explicit Label(uint32_t id) noexcept
     : Operand(Globals::Init, kOpLabel, id, 0, 0) {}
 
   inline explicit Label(Globals::NoInit_) noexcept
@@ -549,7 +549,7 @@ public:
   //! \{
 
   //! Tests whether the label was created by CodeHolder and/or an attached emitter.
-  constexpr bool isValid() const noexcept { return _baseId != Globals::kInvalidId; }
+  ASMJIT_OPERAND_CONSTEXPR bool isValid() const noexcept { return _baseId != Globals::kInvalidId; }
   //! Sets the label `id`.
   inline void setId(uint32_t id) noexcept { _baseId = id; }
 
@@ -684,19 +684,19 @@ public:
   //! \{
 
   //! Creates a dummy register operand.
-  constexpr BaseReg() noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseReg() noexcept
     : Operand(Globals::Init, kSignature, kIdBad, 0, 0) {}
 
   //! Creates a new register operand which is the same as `other` .
-  constexpr BaseReg(const BaseReg& other) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseReg(const BaseReg& other) noexcept
     : Operand(other) {}
 
   //! Creates a new register operand compatible with `other`, but with a different `rId`.
-  constexpr BaseReg(const BaseReg& other, uint32_t rId) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseReg(const BaseReg& other, uint32_t rId) noexcept
     : Operand(Globals::Init, other._signature, rId, 0, 0) {}
 
   //! Creates a register initialized to `signature` and `rId`.
-  constexpr BaseReg(uint32_t signature, uint32_t rId) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseReg(uint32_t signature, uint32_t rId) noexcept
     : Operand(Globals::Init, signature, rId, 0, 0) {}
 
   inline explicit BaseReg(Globals::NoInit_) noexcept
@@ -723,55 +723,55 @@ public:
   //! some one of the two operand contains a garbage or other metadata in the
   //! upper 8 bytes then `isSame()` may return `true` in cases where `isEqual()`
   //! returns false.
-  constexpr bool isSame(const BaseReg& other) const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool isSame(const BaseReg& other) const noexcept {
     return (_signature == other._signature) &
            (_baseId    == other._baseId   ) ;
   }
 
   //! Tests whether the register is valid (either virtual or physical).
-  constexpr bool isValid() const noexcept { return (_signature != 0) & (_baseId != kIdBad); }
+  ASMJIT_OPERAND_CONSTEXPR bool isValid() const noexcept { return (_signature != 0) & (_baseId != kIdBad); }
 
   //! Tests whether this is a physical register.
-  constexpr bool isPhysReg() const noexcept { return _baseId < kIdBad; }
+  ASMJIT_OPERAND_CONSTEXPR bool isPhysReg() const noexcept { return _baseId < kIdBad; }
   //! Tests whether this is a virtual register.
-  constexpr bool isVirtReg() const noexcept { return _baseId > kIdBad; }
+  ASMJIT_OPERAND_CONSTEXPR bool isVirtReg() const noexcept { return _baseId > kIdBad; }
 
   //! Tests whether the register type matches `type` - same as `isReg(type)`, provided for convenience.
-  constexpr bool isType(uint32_t type) const noexcept { return (_signature & kSignatureRegTypeMask) == (type << kSignatureRegTypeShift); }
+  ASMJIT_OPERAND_CONSTEXPR bool isType(uint32_t type) const noexcept { return (_signature & kSignatureRegTypeMask) == (type << kSignatureRegTypeShift); }
   //! Tests whether the register group matches `group`.
-  constexpr bool isGroup(uint32_t group) const noexcept { return (_signature & kSignatureRegGroupMask) == (group << kSignatureRegGroupShift); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGroup(uint32_t group) const noexcept { return (_signature & kSignatureRegGroupMask) == (group << kSignatureRegGroupShift); }
 
   //! Tests whether the register is a general purpose register (any size).
-  constexpr bool isGp() const noexcept { return isGroup(kGroupGp); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGp() const noexcept { return isGroup(kGroupGp); }
   //! Tests whether the register is a vector register.
-  constexpr bool isVec() const noexcept { return isGroup(kGroupVec); }
+  ASMJIT_OPERAND_CONSTEXPR bool isVec() const noexcept { return isGroup(kGroupVec); }
 
   using Operand_::isReg;
 
   //! Same as `isType()`, provided for convenience.
-  constexpr bool isReg(uint32_t rType) const noexcept { return isType(rType); }
+  ASMJIT_OPERAND_CONSTEXPR bool isReg(uint32_t rType) const noexcept { return isType(rType); }
   //! Tests whether the register type matches `type` and register id matches `rId`.
-  constexpr bool isReg(uint32_t rType, uint32_t rId) const noexcept { return isType(rType) && id() == rId; }
+  ASMJIT_OPERAND_CONSTEXPR bool isReg(uint32_t rType, uint32_t rId) const noexcept { return isType(rType) && id() == rId; }
 
   //! Returns the type of the register.
-  constexpr uint32_t type() const noexcept { return _getSignaturePart<kSignatureRegTypeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t type() const noexcept { return _getSignaturePart<kSignatureRegTypeMask>(); }
   //! Returns the register group.
-  constexpr uint32_t group() const noexcept { return _getSignaturePart<kSignatureRegGroupMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t group() const noexcept { return _getSignaturePart<kSignatureRegGroupMask>(); }
 
   //! Clones the register operand.
-  constexpr BaseReg clone() const noexcept { return BaseReg(*this); }
+  ASMJIT_OPERAND_CONSTEXPR BaseReg clone() const noexcept { return BaseReg(*this); }
 
   //! Casts this register to `RegT` by also changing its signature.
   //!
   //! \note Improper use of `cloneAs()` can lead to hard-to-debug errors.
   template<typename RegT>
-  constexpr RegT cloneAs() const noexcept { return RegT(RegT::kSignature, id()); }
+  ASMJIT_OPERAND_CONSTEXPR RegT cloneAs() const noexcept { return RegT(RegT::kSignature, id()); }
 
   //! Casts this register to `other` by also changing its signature.
   //!
   //! \note Improper use of `cloneAs()` can lead to hard-to-debug errors.
   template<typename RegT>
-  constexpr RegT cloneAs(const RegT& other) const noexcept { return RegT(other.signature(), id()); }
+  ASMJIT_OPERAND_CONSTEXPR RegT cloneAs(const RegT& other) const noexcept { return RegT(other.signature(), id()); }
 
   //! Sets the register id to `rId`.
   inline void setId(uint32_t rId) noexcept { _baseId = rId; }
@@ -890,7 +890,7 @@ struct RegOnly {
 
   //! Converts this ExtraReg to a real `RegT` operand.
   template<typename RegT>
-  constexpr RegT toReg() const noexcept { return RegT(_signature, _id); }
+  ASMJIT_OPERAND_CONSTEXPR RegT toReg() const noexcept { return RegT(_signature, _id); }
 
   //! \}
 };
@@ -957,20 +957,20 @@ public:
   //! \{
 
   //! Creates a default `BaseMem` operand, that points to [0].
-  constexpr BaseMem() noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseMem() noexcept
     : Operand(Globals::Init, kOpMem, 0, 0, 0) {}
 
   //! Creates a `BaseMem` operand that is a clone of `other`.
-  constexpr BaseMem(const BaseMem& other) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseMem(const BaseMem& other) noexcept
     : Operand(other) {}
 
   //! \cond INTERNAL
 
   //! Creates a `BaseMem` operand from 4 integers as used by `Operand_` struct.
-  constexpr BaseMem(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseMem(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
     : Operand(Globals::Init, u0, u1, u2, u3) {}
 
-  constexpr BaseMem(const Decomposed& d) noexcept
+  ASMJIT_OPERAND_CONSTEXPR BaseMem(const Decomposed& d) noexcept
     : Operand(Globals::Init,
               kOpMem | (d.baseType  << kSignatureMemBaseTypeShift )
                      | (d.indexType << kSignatureMemIndexTypeShift)
@@ -1006,37 +1006,37 @@ public:
   //! \{
 
   //! Clones the memory operand.
-  constexpr BaseMem clone() const noexcept { return BaseMem(*this); }
+  ASMJIT_OPERAND_CONSTEXPR BaseMem clone() const noexcept { return BaseMem(*this); }
 
-  constexpr uint32_t addrType() const noexcept { return _getSignaturePart<kSignatureMemAddrTypeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t addrType() const noexcept { return _getSignaturePart<kSignatureMemAddrTypeMask>(); }
   inline void setAddrType(uint32_t addrType) noexcept { _setSignaturePart<kSignatureMemAddrTypeMask>(addrType); }
   inline void resetAddrType() noexcept { _setSignaturePart<kSignatureMemAddrTypeMask>(0); }
 
-  constexpr bool isAbs() const noexcept { return addrType() == kAddrTypeAbs; }
+  ASMJIT_OPERAND_CONSTEXPR bool isAbs() const noexcept { return addrType() == kAddrTypeAbs; }
   inline void setAbs() noexcept { setAddrType(kAddrTypeAbs); }
 
-  constexpr bool isRel() const noexcept { return addrType() == kAddrTypeRel; }
+  ASMJIT_OPERAND_CONSTEXPR bool isRel() const noexcept { return addrType() == kAddrTypeRel; }
   inline void setRel() noexcept { setAddrType(kAddrTypeRel); }
 
-  constexpr bool isRegHome() const noexcept { return _hasSignaturePart<kSignatureMemRegHomeFlag>(); }
+  ASMJIT_OPERAND_CONSTEXPR bool isRegHome() const noexcept { return _hasSignaturePart<kSignatureMemRegHomeFlag>(); }
   inline void setRegHome() noexcept { _signature |= kSignatureMemRegHomeFlag; }
   inline void clearRegHome() noexcept { _signature &= ~kSignatureMemRegHomeFlag; }
 
   //! Tests whether the memory operand has a BASE register or label specified.
-  constexpr bool hasBase() const noexcept { return (_signature & kSignatureMemBaseTypeMask) != 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBase() const noexcept { return (_signature & kSignatureMemBaseTypeMask) != 0; }
   //! Tests whether the memory operand has an INDEX register specified.
-  constexpr bool hasIndex() const noexcept { return (_signature & kSignatureMemIndexTypeMask) != 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasIndex() const noexcept { return (_signature & kSignatureMemIndexTypeMask) != 0; }
   //! Tests whether the memory operand has BASE and INDEX register.
-  constexpr bool hasBaseOrIndex() const noexcept { return (_signature & kSignatureMemBaseIndexMask) != 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBaseOrIndex() const noexcept { return (_signature & kSignatureMemBaseIndexMask) != 0; }
   //! Tests whether the memory operand has BASE and INDEX register.
-  constexpr bool hasBaseAndIndex() const noexcept { return (_signature & kSignatureMemBaseTypeMask) != 0 && (_signature & kSignatureMemIndexTypeMask) != 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBaseAndIndex() const noexcept { return (_signature & kSignatureMemBaseTypeMask) != 0 && (_signature & kSignatureMemIndexTypeMask) != 0; }
 
   //! Tests whether the BASE operand is a register (registers start after `kLabelTag`).
-  constexpr bool hasBaseReg() const noexcept { return (_signature & kSignatureMemBaseTypeMask) > (Label::kLabelTag << kSignatureMemBaseTypeShift); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBaseReg() const noexcept { return (_signature & kSignatureMemBaseTypeMask) > (Label::kLabelTag << kSignatureMemBaseTypeShift); }
   //! Tests whether the BASE operand is a label.
-  constexpr bool hasBaseLabel() const noexcept { return (_signature & kSignatureMemBaseTypeMask) == (Label::kLabelTag << kSignatureMemBaseTypeShift); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBaseLabel() const noexcept { return (_signature & kSignatureMemBaseTypeMask) == (Label::kLabelTag << kSignatureMemBaseTypeShift); }
   //! Tests whether the INDEX operand is a register (registers start after `kLabelTag`).
-  constexpr bool hasIndexReg() const noexcept { return (_signature & kSignatureMemIndexTypeMask) > (Label::kLabelTag << kSignatureMemIndexTypeShift); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasIndexReg() const noexcept { return (_signature & kSignatureMemIndexTypeMask) > (Label::kLabelTag << kSignatureMemIndexTypeShift); }
 
   //! Returns the type of the BASE register (0 if this memory operand doesn't
   //! use the BASE register).
@@ -1044,24 +1044,24 @@ public:
   //! \note If the returned type is one (a value never associated to a register
   //! type) the BASE is not register, but it's a label. One equals to `kLabelTag`.
   //! You should always check `hasBaseLabel()` before using `baseId()` result.
-  constexpr uint32_t baseType() const noexcept { return _getSignaturePart<kSignatureMemBaseTypeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t baseType() const noexcept { return _getSignaturePart<kSignatureMemBaseTypeMask>(); }
 
   //! Returns the type of an INDEX register (0 if this memory operand doesn't
   //! use the INDEX register).
-  constexpr uint32_t indexType() const noexcept { return _getSignaturePart<kSignatureMemIndexTypeMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t indexType() const noexcept { return _getSignaturePart<kSignatureMemIndexTypeMask>(); }
 
   //! This is used internally for BASE+INDEX validation.
-  constexpr uint32_t baseAndIndexTypes() const noexcept { return _getSignaturePart<kSignatureMemBaseIndexMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t baseAndIndexTypes() const noexcept { return _getSignaturePart<kSignatureMemBaseIndexMask>(); }
 
   //! Returns both BASE (4:0 bits) and INDEX (9:5 bits) types combined into a
   //! single value.
   //!
   //! \remarks Returns id of the BASE register or label (if the BASE was
   //! specified as label).
-  constexpr uint32_t baseId() const noexcept { return _baseId; }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t baseId() const noexcept { return _baseId; }
 
   //! Returns the id of the INDEX register.
-  constexpr uint32_t indexId() const noexcept { return _mem.indexId; }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t indexId() const noexcept { return _mem.indexId; }
 
   //! Sets the id of the BASE register (without modifying its type).
   inline void setBaseId(uint32_t rId) noexcept { _baseId = rId; }
@@ -1094,26 +1094,26 @@ public:
   //! Tests whether the memory operand has a 64-bit offset or absolute address.
   //!
   //! If this is true then `hasBase()` must always report false.
-  constexpr bool isOffset64Bit() const noexcept { return baseType() == 0; }
+  ASMJIT_OPERAND_CONSTEXPR bool isOffset64Bit() const noexcept { return baseType() == 0; }
 
   //! Tests whether the memory operand has a non-zero offset or absolute address.
-  constexpr bool hasOffset() const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR bool hasOffset() const noexcept {
     return (_mem.offsetLo32 | uint32_t(_baseId & Support::bitMaskFromBool<uint32_t>(isOffset64Bit()))) != 0;
   }
 
   //! Returns either relative offset or absolute address as 64-bit integer.
-  constexpr int64_t offset() const noexcept {
+  ASMJIT_OPERAND_CONSTEXPR int64_t offset() const noexcept {
     return isOffset64Bit() ? int64_t(uint64_t(_mem.offsetLo32) | (uint64_t(_baseId) << 32))
                            : int64_t(int32_t(_mem.offsetLo32)); // Sign extend 32-bit offset.
   }
 
   //! Returns a 32-bit low part of a 64-bit offset or absolute address.
-  constexpr int32_t offsetLo32() const noexcept { return int32_t(_mem.offsetLo32); }
+  ASMJIT_OPERAND_CONSTEXPR int32_t offsetLo32() const noexcept { return int32_t(_mem.offsetLo32); }
   //! Returns a 32-but high part of a 64-bit offset or absolute address.
   //!
   //! \note This function is UNSAFE and returns garbage if `isOffset64Bit()`
   //! returns false. Never use it blindly without checking it first.
-  constexpr int32_t offsetHi32() const noexcept { return int32_t(_baseId); }
+  ASMJIT_OPERAND_CONSTEXPR int32_t offsetHi32() const noexcept { return int32_t(_baseId); }
 
   //! Sets a 64-bit offset or an absolute address to `offset`.
   //!
@@ -1183,15 +1183,15 @@ public:
   //! \{
 
   //! Creates a new immediate value (initial value is 0).
-  constexpr Imm() noexcept
+  ASMJIT_OPERAND_CONSTEXPR Imm() noexcept
     : Operand(Globals::Init, kOpImm, 0, 0, 0) {}
 
   //! Creates a new immediate value from `other`.
-  constexpr Imm(const Imm& other) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Imm(const Imm& other) noexcept
     : Operand(other) {}
 
   //! Creates a new signed immediate value, assigning the value to `val`.
-  constexpr explicit Imm(int64_t val) noexcept
+  ASMJIT_OPERAND_CONSTEXPR explicit Imm(int64_t val) noexcept
     : Operand(Globals::Init, kOpImm, 0, Support::unpackU32At0(val), Support::unpackU32At1(val)) {}
 
   inline explicit Imm(Globals::NoInit_) noexcept
@@ -1211,46 +1211,46 @@ public:
   //! \{
 
   //! Tests whether the immediate can be casted to 8-bit signed integer.
-  constexpr bool isInt8() const noexcept { return Support::isInt8(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isInt8() const noexcept { return Support::isInt8(int64_t(_data64)); }
   //! Tests whether the immediate can be casted to 8-bit unsigned integer.
-  constexpr bool isUInt8() const noexcept { return Support::isUInt8(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isUInt8() const noexcept { return Support::isUInt8(int64_t(_data64)); }
   //! Tests whether the immediate can be casted to 16-bit signed integer.
-  constexpr bool isInt16() const noexcept { return Support::isInt16(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isInt16() const noexcept { return Support::isInt16(int64_t(_data64)); }
   //! Tests whether the immediate can be casted to 16-bit unsigned integer.
-  constexpr bool isUInt16() const noexcept { return Support::isUInt16(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isUInt16() const noexcept { return Support::isUInt16(int64_t(_data64)); }
   //! Tests whether the immediate can be casted to 32-bit signed integer.
-  constexpr bool isInt32() const noexcept { return Support::isInt32(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isInt32() const noexcept { return Support::isInt32(int64_t(_data64)); }
   //! Tests whether the immediate can be casted to 32-bit unsigned integer.
-  constexpr bool isUInt32() const noexcept { return Support::isUInt32(int64_t(_data64)); }
+  ASMJIT_OPERAND_CONSTEXPR bool isUInt32() const noexcept { return Support::isUInt32(int64_t(_data64)); }
 
   //! Returns immediate value as 8-bit signed integer, possibly cropped.
-  constexpr int8_t i8() const noexcept { return int8_t(_data64 & 0xFFu); }
+  ASMJIT_OPERAND_CONSTEXPR int8_t i8() const noexcept { return int8_t(_data64 & 0xFFu); }
   //! Returns immediate value as 8-bit unsigned integer, possibly cropped.
-  constexpr uint8_t u8() const noexcept { return uint8_t(_data64 & 0xFFu); }
+  ASMJIT_OPERAND_CONSTEXPR uint8_t u8() const noexcept { return uint8_t(_data64 & 0xFFu); }
   //! Returns immediate value as 16-bit signed integer, possibly cropped.
-  constexpr int16_t i16() const noexcept { return int16_t(_data64 & 0xFFFFu);}
+  ASMJIT_OPERAND_CONSTEXPR int16_t i16() const noexcept { return int16_t(_data64 & 0xFFFFu);}
   //! Returns immediate value as 16-bit unsigned integer, possibly cropped.
-  constexpr uint16_t u16() const noexcept { return uint16_t(_data64 & 0xFFFFu);}
+  ASMJIT_OPERAND_CONSTEXPR uint16_t u16() const noexcept { return uint16_t(_data64 & 0xFFFFu);}
   //! Returns immediate value as 32-bit signed integer, possibly cropped.
-  constexpr int32_t i32() const noexcept { return int32_t(_data64 & 0xFFFFFFFFu); }
+  ASMJIT_OPERAND_CONSTEXPR int32_t i32() const noexcept { return int32_t(_data64 & 0xFFFFFFFFu); }
   //! Returns low 32-bit signed integer.
-  constexpr int32_t i32Lo() const noexcept { return int32_t(_data64 & 0xFFFFFFFFu); }
+  ASMJIT_OPERAND_CONSTEXPR int32_t i32Lo() const noexcept { return int32_t(_data64 & 0xFFFFFFFFu); }
   //! Returns high 32-bit signed integer.
-  constexpr int32_t i32Hi() const noexcept { return int32_t(_data64 >> 32); }
+  ASMJIT_OPERAND_CONSTEXPR int32_t i32Hi() const noexcept { return int32_t(_data64 >> 32); }
   //! Returns immediate value as 32-bit unsigned integer, possibly cropped.
-  constexpr uint32_t u32() const noexcept { return uint32_t(_data64 & 0xFFFFFFFFu); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t u32() const noexcept { return uint32_t(_data64 & 0xFFFFFFFFu); }
   //! Returns low 32-bit signed integer.
-  constexpr uint32_t u32Lo() const noexcept { return uint32_t(_data64 & 0xFFFFFFFFu); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t u32Lo() const noexcept { return uint32_t(_data64 & 0xFFFFFFFFu); }
   //! Returns high 32-bit signed integer.
-  constexpr uint32_t u32Hi() const noexcept { return uint32_t(_data64 >> 32); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t u32Hi() const noexcept { return uint32_t(_data64 >> 32); }
   //! Returns immediate value as 64-bit signed integer.
-  constexpr int64_t i64() const noexcept { return int64_t(_data64); }
+  ASMJIT_OPERAND_CONSTEXPR int64_t i64() const noexcept { return int64_t(_data64); }
   //! Returns immediate value as 64-bit unsigned integer.
-  constexpr uint64_t u64() const noexcept { return _data64; }
+  ASMJIT_OPERAND_CONSTEXPR uint64_t u64() const noexcept { return _data64; }
   //! Returns immediate value as `intptr_t`, possibly cropped if size of `intptr_t` is 32 bits.
-  constexpr intptr_t iptr() const noexcept { return (sizeof(intptr_t) == sizeof(int64_t)) ? intptr_t(_data64) : intptr_t(i32()); }
+  ASMJIT_OPERAND_CONSTEXPR intptr_t iptr() const noexcept { return (sizeof(intptr_t) == sizeof(int64_t)) ? intptr_t(_data64) : intptr_t(i32()); }
   //! Returns immediate value as `uintptr_t`, possibly cropped if size of `uintptr_t` is 32 bits.
-  constexpr uintptr_t uptr() const noexcept { return (sizeof(uintptr_t) == sizeof(uint64_t)) ? uintptr_t(_data64) : uintptr_t(u32()); }
+  ASMJIT_OPERAND_CONSTEXPR uintptr_t uptr() const noexcept { return (sizeof(uintptr_t) == sizeof(uint64_t)) ? uintptr_t(_data64) : uintptr_t(u32()); }
 
   //! Sets immediate value to 8-bit signed integer `val`.
   inline void setI8(int8_t val) noexcept { _data64 = uint64_t(int64_t(val)); }
@@ -1287,7 +1287,7 @@ public:
   //! \{
 
   //! Clones the immediate operand.
-  constexpr Imm clone() const noexcept { return Imm(*this); }
+  ASMJIT_OPERAND_CONSTEXPR Imm clone() const noexcept { return Imm(*this); }
 
   inline void signExtend8Bits() noexcept { _data64 = uint64_t(int64_t(i8())); }
   inline void signExtend16Bits() noexcept { _data64 = uint64_t(int64_t(i16())); }
@@ -1305,7 +1305,7 @@ public:
 //! Using `imm(x)` is much nicer than using `Imm(x)` as this is a template
 //! which can accept any integer including pointers and function pointers.
 template<typename T>
-static constexpr Imm imm(T val) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Imm imm(T val) noexcept {
   return Imm(std::is_signed<T>::value ? int64_t(val) : int64_t(uint64_t(val)));
 }
 

--- a/src/asmjit/x86/x86operand.h
+++ b/src/asmjit/x86/x86operand.h
@@ -128,39 +128,39 @@ public:
   };
 
   //! Tests whether the register is a GPB register (8-bit).
-  constexpr bool isGpb() const noexcept { return size() == 1; }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpb() const noexcept { return size() == 1; }
   //! Tests whether the register is a low GPB register (8-bit).
-  constexpr bool isGpbLo() const noexcept { return hasSignature(RegTraits<kTypeGpbLo>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpbLo() const noexcept { return hasSignature(RegTraits<kTypeGpbLo>::kSignature); }
   //! Tests whether the register is a high GPB register (8-bit).
-  constexpr bool isGpbHi() const noexcept { return hasSignature(RegTraits<kTypeGpbHi>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpbHi() const noexcept { return hasSignature(RegTraits<kTypeGpbHi>::kSignature); }
   //! Tests whether the register is a GPW register (16-bit).
-  constexpr bool isGpw() const noexcept { return hasSignature(RegTraits<kTypeGpw>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpw() const noexcept { return hasSignature(RegTraits<kTypeGpw>::kSignature); }
   //! Tests whether the register is a GPD register (32-bit).
-  constexpr bool isGpd() const noexcept { return hasSignature(RegTraits<kTypeGpd>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpd() const noexcept { return hasSignature(RegTraits<kTypeGpd>::kSignature); }
   //! Tests whether the register is a GPQ register (64-bit).
-  constexpr bool isGpq() const noexcept { return hasSignature(RegTraits<kTypeGpq>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isGpq() const noexcept { return hasSignature(RegTraits<kTypeGpq>::kSignature); }
   //! Tests whether the register is an XMM register (128-bit).
-  constexpr bool isXmm() const noexcept { return hasSignature(RegTraits<kTypeXmm>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isXmm() const noexcept { return hasSignature(RegTraits<kTypeXmm>::kSignature); }
   //! Tests whether the register is a YMM register (256-bit).
-  constexpr bool isYmm() const noexcept { return hasSignature(RegTraits<kTypeYmm>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isYmm() const noexcept { return hasSignature(RegTraits<kTypeYmm>::kSignature); }
   //! Tests whether the register is a ZMM register (512-bit).
-  constexpr bool isZmm() const noexcept { return hasSignature(RegTraits<kTypeZmm>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isZmm() const noexcept { return hasSignature(RegTraits<kTypeZmm>::kSignature); }
   //! Tests whether the register is an MMX register (64-bit).
-  constexpr bool isMm() const noexcept { return hasSignature(RegTraits<kTypeMm>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isMm() const noexcept { return hasSignature(RegTraits<kTypeMm>::kSignature); }
   //! Tests whether the register is a K register (64-bit).
-  constexpr bool isKReg() const noexcept { return hasSignature(RegTraits<kTypeKReg>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isKReg() const noexcept { return hasSignature(RegTraits<kTypeKReg>::kSignature); }
   //! Tests whether the register is a segment register.
-  constexpr bool isSReg() const noexcept { return hasSignature(RegTraits<kTypeSReg>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isSReg() const noexcept { return hasSignature(RegTraits<kTypeSReg>::kSignature); }
   //! Tests whether the register is a control register.
-  constexpr bool isCReg() const noexcept { return hasSignature(RegTraits<kTypeCReg>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isCReg() const noexcept { return hasSignature(RegTraits<kTypeCReg>::kSignature); }
   //! Tests whether the register is a debug register.
-  constexpr bool isDReg() const noexcept { return hasSignature(RegTraits<kTypeDReg>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isDReg() const noexcept { return hasSignature(RegTraits<kTypeDReg>::kSignature); }
   //! Tests whether the register is an FPU register (80-bit).
-  constexpr bool isSt() const noexcept { return hasSignature(RegTraits<kTypeSt>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isSt() const noexcept { return hasSignature(RegTraits<kTypeSt>::kSignature); }
   //! Tests whether the register is a bound register.
-  constexpr bool isBnd() const noexcept { return hasSignature(RegTraits<kTypeBnd>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isBnd() const noexcept { return hasSignature(RegTraits<kTypeBnd>::kSignature); }
   //! Tests whether the register is RIP.
-  constexpr bool isRip() const noexcept { return hasSignature(RegTraits<kTypeRip>::kSignature); }
+  ASMJIT_OPERAND_CONSTEXPR bool isRip() const noexcept { return hasSignature(RegTraits<kTypeRip>::kSignature); }
 
   template<uint32_t REG_TYPE>
   inline void setRegT(uint32_t rId) noexcept {
@@ -420,45 +420,45 @@ public:
   // --------------------------------------------------------------------------
 
   //! Creates a default `Mem` operand that points to [0].
-  constexpr Mem() noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem() noexcept
     : BaseMem() {}
 
-  constexpr Mem(const Mem& other) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(const Mem& other) noexcept
     : BaseMem(other) {}
 
   //! \cond INTERNAL
   //!
   //! A constructor used internally to create `Mem` operand from `Decomposed` data.
-  constexpr explicit Mem(const Decomposed& d) noexcept
+  ASMJIT_OPERAND_CONSTEXPR explicit Mem(const Decomposed& d) noexcept
     : BaseMem(d) {}
   //! \endcond
 
-  constexpr Mem(const Label& base, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(const Label& base, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { Label::kLabelTag, base.id(), 0, 0, off, size, flags }) {}
 
-  constexpr Mem(const Label& base, const BaseReg& index, uint32_t shift, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(const Label& base, const BaseReg& index, uint32_t shift, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { Label::kLabelTag, base.id(), index.type(), index.id(), off, size, flags | (shift << kSignatureMemShiftShift) }) {}
 
-  constexpr Mem(const BaseReg& base, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(const BaseReg& base, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { base.type(), base.id(), 0, 0, off, size, flags }) {}
 
-  constexpr Mem(const BaseReg& base, const BaseReg& index, uint32_t shift, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(const BaseReg& base, const BaseReg& index, uint32_t shift, int32_t off, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { base.type(), base.id(), index.type(), index.id(), off, size, flags | (shift << kSignatureMemShiftShift) }) {}
 
-  constexpr explicit Mem(uint64_t base, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR explicit Mem(uint64_t base, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { 0, uint32_t(base >> 32), 0, 0, int32_t(uint32_t(base & 0xFFFFFFFFu)), size, flags }) {}
 
-  constexpr Mem(uint64_t base, const BaseReg& index, uint32_t shift = 0, uint32_t size = 0, uint32_t flags = 0) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(uint64_t base, const BaseReg& index, uint32_t shift = 0, uint32_t size = 0, uint32_t flags = 0) noexcept
     : BaseMem(Decomposed { 0, uint32_t(base >> 32), index.type(), index.id(), int32_t(uint32_t(base & 0xFFFFFFFFu)), size, flags | (shift << kSignatureMemShiftShift) }) {}
 
-  constexpr Mem(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
+  ASMJIT_OPERAND_CONSTEXPR Mem(Globals::Init_, uint32_t u0, uint32_t u1, uint32_t u2, uint32_t u3) noexcept
     : BaseMem(Globals::Init, u0, u1, u2, u3) {}
 
   inline explicit Mem(Globals::NoInit_) noexcept
     : BaseMem(Globals::NoInit) {}
 
   //! Clones the memory operand.
-  constexpr Mem clone() const noexcept { return Mem(*this); }
+  ASMJIT_OPERAND_CONSTEXPR Mem clone() const noexcept { return Mem(*this); }
 
   //! Creates a new copy of this memory operand adjusted by `off`.
   inline Mem cloneAdjusted(int64_t off) const noexcept {
@@ -477,13 +477,13 @@ public:
   //! The memory must have a valid index register otherwise the result will be wrong.
   inline Reg indexReg() const noexcept { return Reg::fromTypeAndId(indexType(), indexId()); }
 
-  constexpr Mem _1to1() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To1 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to2() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To2 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to4() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To4 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to8() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To8 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to16() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To16 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to32() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To32 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
-  constexpr Mem _1to64() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To64 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to1() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To1 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to2() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To2 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to4() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To4 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to8() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To8 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to16() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To16 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to32() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To32 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
+  ASMJIT_OPERAND_CONSTEXPR Mem _1to64() const noexcept { return Mem(Globals::Init, (_signature & ~kSignatureMemBroadcastMask) | (kBroadcast1To64 << kSignatureMemBroadcastShift), _baseId, _data32[0], _data32[1]); }
 
   // --------------------------------------------------------------------------
   // [Mem]
@@ -497,11 +497,11 @@ public:
   }
 
   //! Tests whether the memory operand has a segment override.
-  constexpr bool hasSegment() const noexcept { return _hasSignaturePart<kSignatureMemSegmentMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasSegment() const noexcept { return _hasSignaturePart<kSignatureMemSegmentMask>(); }
   //! Returns the associated segment override as `SReg` operand.
-  constexpr SReg segment() const noexcept { return SReg(segmentId()); }
+  ASMJIT_OPERAND_CONSTEXPR SReg segment() const noexcept { return SReg(segmentId()); }
   //! Returns segment override register id, see `SReg::Id`.
-  constexpr uint32_t segmentId() const noexcept { return _getSignaturePart<kSignatureMemSegmentMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t segmentId() const noexcept { return _getSignaturePart<kSignatureMemSegmentMask>(); }
 
   //! Sets the segment override to `seg`.
   inline void setSegment(const SReg& seg) noexcept { setSegment(seg.id()); }
@@ -511,18 +511,18 @@ public:
   inline void resetSegment() noexcept { _setSignaturePart<kSignatureMemSegmentMask>(0); }
 
   //! Tests whether the memory operand has shift (aka scale) value.
-  constexpr bool hasShift() const noexcept { return _hasSignaturePart<kSignatureMemShiftMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasShift() const noexcept { return _hasSignaturePart<kSignatureMemShiftMask>(); }
   //! Returns the memory operand's shift (aka scale) value.
-  constexpr uint32_t shift() const noexcept { return _getSignaturePart<kSignatureMemShiftMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t shift() const noexcept { return _getSignaturePart<kSignatureMemShiftMask>(); }
   //! Sets the memory operand's shift (aka scale) value.
   inline void setShift(uint32_t shift) noexcept { _setSignaturePart<kSignatureMemShiftMask>(shift); }
   //! Resets the memory operand's shift (aka scale) value to zero.
   inline void resetShift() noexcept { _setSignaturePart<kSignatureMemShiftMask>(0); }
 
   //! Tests whether the memory operand has broadcast {1tox}.
-  constexpr bool hasBroadcast() const noexcept { return _hasSignaturePart<kSignatureMemBroadcastMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR bool hasBroadcast() const noexcept { return _hasSignaturePart<kSignatureMemBroadcastMask>(); }
   //! Returns the memory operand's broadcast.
-  constexpr uint32_t getBroadcast() const noexcept { return _getSignaturePart<kSignatureMemBroadcastMask>(); }
+  ASMJIT_OPERAND_CONSTEXPR uint32_t getBroadcast() const noexcept { return _getSignaturePart<kSignatureMemBroadcastMask>(); }
   //! Sets the memory operand's broadcast.
   inline void setBroadcast(uint32_t bcst) noexcept { _setSignaturePart<kSignatureMemBroadcastMask>(bcst); }
   //! Resets the memory operand's broadcast to none.
@@ -570,283 +570,283 @@ inline uint32_t Reg::signatureOf(uint32_t rType) noexcept {
 namespace regs {
 
 //! Creates an 8-bit low GPB register operand.
-static constexpr GpbLo gpb(uint32_t rId) noexcept { return GpbLo(rId); }
+static ASMJIT_OPERAND_CONSTEXPR GpbLo gpb(uint32_t rId) noexcept { return GpbLo(rId); }
 //! Creates an 8-bit low GPB register operand.
-static constexpr GpbLo gpb_lo(uint32_t rId) noexcept { return GpbLo(rId); }
+static ASMJIT_OPERAND_CONSTEXPR GpbLo gpb_lo(uint32_t rId) noexcept { return GpbLo(rId); }
 //! Creates an 8-bit high GPB register operand.
-static constexpr GpbHi gpb_hi(uint32_t rId) noexcept { return GpbHi(rId); }
+static ASMJIT_OPERAND_CONSTEXPR GpbHi gpb_hi(uint32_t rId) noexcept { return GpbHi(rId); }
 //! Creates a 16-bit GPW register operand.
-static constexpr Gpw gpw(uint32_t rId) noexcept { return Gpw(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Gpw gpw(uint32_t rId) noexcept { return Gpw(rId); }
 //! Creates a 32-bit GPD register operand.
-static constexpr Gpd gpd(uint32_t rId) noexcept { return Gpd(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Gpd gpd(uint32_t rId) noexcept { return Gpd(rId); }
 //! Creates a 64-bit GPQ register operand (64-bit).
-static constexpr Gpq gpq(uint32_t rId) noexcept { return Gpq(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Gpq gpq(uint32_t rId) noexcept { return Gpq(rId); }
 //! Creates a 128-bit XMM register operand.
-static constexpr Xmm xmm(uint32_t rId) noexcept { return Xmm(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm(uint32_t rId) noexcept { return Xmm(rId); }
 //! Creates a 256-bit YMM register operand.
-static constexpr Ymm ymm(uint32_t rId) noexcept { return Ymm(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm(uint32_t rId) noexcept { return Ymm(rId); }
 //! Creates a 512-bit ZMM register operand.
-static constexpr Zmm zmm(uint32_t rId) noexcept { return Zmm(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm(uint32_t rId) noexcept { return Zmm(rId); }
 //! Creates a 64-bit Mm register operand.
-static constexpr Mm mm(uint32_t rId) noexcept { return Mm(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Mm mm(uint32_t rId) noexcept { return Mm(rId); }
 //! Creates a 64-bit K register operand.
-static constexpr KReg k(uint32_t rId) noexcept { return KReg(rId); }
+static ASMJIT_OPERAND_CONSTEXPR KReg k(uint32_t rId) noexcept { return KReg(rId); }
 //! Creates a 32-bit or 64-bit control register operand.
-static constexpr CReg cr(uint32_t rId) noexcept { return CReg(rId); }
+static ASMJIT_OPERAND_CONSTEXPR CReg cr(uint32_t rId) noexcept { return CReg(rId); }
 //! Creates a 32-bit or 64-bit debug register operand.
-static constexpr DReg dr(uint32_t rId) noexcept { return DReg(rId); }
+static ASMJIT_OPERAND_CONSTEXPR DReg dr(uint32_t rId) noexcept { return DReg(rId); }
 //! Creates an 80-bit st register operand.
-static constexpr St st(uint32_t rId) noexcept { return St(rId); }
+static ASMJIT_OPERAND_CONSTEXPR St st(uint32_t rId) noexcept { return St(rId); }
 //! Creates a 128-bit bound register operand.
-static constexpr Bnd bnd(uint32_t rId) noexcept { return Bnd(rId); }
+static ASMJIT_OPERAND_CONSTEXPR Bnd bnd(uint32_t rId) noexcept { return Bnd(rId); }
 
-static constexpr Gp al(GpbLo::kSignature, Gp::kIdAx);
-static constexpr Gp bl(GpbLo::kSignature, Gp::kIdBx);
-static constexpr Gp cl(GpbLo::kSignature, Gp::kIdCx);
-static constexpr Gp dl(GpbLo::kSignature, Gp::kIdDx);
-static constexpr Gp spl(GpbLo::kSignature, Gp::kIdSp);
-static constexpr Gp bpl(GpbLo::kSignature, Gp::kIdBp);
-static constexpr Gp sil(GpbLo::kSignature, Gp::kIdSi);
-static constexpr Gp dil(GpbLo::kSignature, Gp::kIdDi);
-static constexpr Gp r8b(GpbLo::kSignature, Gp::kIdR8);
-static constexpr Gp r9b(GpbLo::kSignature, Gp::kIdR9);
-static constexpr Gp r10b(GpbLo::kSignature, Gp::kIdR10);
-static constexpr Gp r11b(GpbLo::kSignature, Gp::kIdR11);
-static constexpr Gp r12b(GpbLo::kSignature, Gp::kIdR12);
-static constexpr Gp r13b(GpbLo::kSignature, Gp::kIdR13);
-static constexpr Gp r14b(GpbLo::kSignature, Gp::kIdR14);
-static constexpr Gp r15b(GpbLo::kSignature, Gp::kIdR15);
+static ASMJIT_OPERAND_CONSTEXPR Gp al(GpbLo::kSignature, Gp::kIdAx);
+static ASMJIT_OPERAND_CONSTEXPR Gp bl(GpbLo::kSignature, Gp::kIdBx);
+static ASMJIT_OPERAND_CONSTEXPR Gp cl(GpbLo::kSignature, Gp::kIdCx);
+static ASMJIT_OPERAND_CONSTEXPR Gp dl(GpbLo::kSignature, Gp::kIdDx);
+static ASMJIT_OPERAND_CONSTEXPR Gp spl(GpbLo::kSignature, Gp::kIdSp);
+static ASMJIT_OPERAND_CONSTEXPR Gp bpl(GpbLo::kSignature, Gp::kIdBp);
+static ASMJIT_OPERAND_CONSTEXPR Gp sil(GpbLo::kSignature, Gp::kIdSi);
+static ASMJIT_OPERAND_CONSTEXPR Gp dil(GpbLo::kSignature, Gp::kIdDi);
+static ASMJIT_OPERAND_CONSTEXPR Gp r8b(GpbLo::kSignature, Gp::kIdR8);
+static ASMJIT_OPERAND_CONSTEXPR Gp r9b(GpbLo::kSignature, Gp::kIdR9);
+static ASMJIT_OPERAND_CONSTEXPR Gp r10b(GpbLo::kSignature, Gp::kIdR10);
+static ASMJIT_OPERAND_CONSTEXPR Gp r11b(GpbLo::kSignature, Gp::kIdR11);
+static ASMJIT_OPERAND_CONSTEXPR Gp r12b(GpbLo::kSignature, Gp::kIdR12);
+static ASMJIT_OPERAND_CONSTEXPR Gp r13b(GpbLo::kSignature, Gp::kIdR13);
+static ASMJIT_OPERAND_CONSTEXPR Gp r14b(GpbLo::kSignature, Gp::kIdR14);
+static ASMJIT_OPERAND_CONSTEXPR Gp r15b(GpbLo::kSignature, Gp::kIdR15);
 
-static constexpr Gp ah(GpbHi::kSignature, Gp::kIdAx);
-static constexpr Gp bh(GpbHi::kSignature, Gp::kIdBx);
-static constexpr Gp ch(GpbHi::kSignature, Gp::kIdCx);
-static constexpr Gp dh(GpbHi::kSignature, Gp::kIdDx);
+static ASMJIT_OPERAND_CONSTEXPR Gp ah(GpbHi::kSignature, Gp::kIdAx);
+static ASMJIT_OPERAND_CONSTEXPR Gp bh(GpbHi::kSignature, Gp::kIdBx);
+static ASMJIT_OPERAND_CONSTEXPR Gp ch(GpbHi::kSignature, Gp::kIdCx);
+static ASMJIT_OPERAND_CONSTEXPR Gp dh(GpbHi::kSignature, Gp::kIdDx);
 
-static constexpr Gp ax(Gpw::kSignature, Gp::kIdAx);
-static constexpr Gp bx(Gpw::kSignature, Gp::kIdBx);
-static constexpr Gp cx(Gpw::kSignature, Gp::kIdCx);
-static constexpr Gp dx(Gpw::kSignature, Gp::kIdDx);
-static constexpr Gp sp(Gpw::kSignature, Gp::kIdSp);
-static constexpr Gp bp(Gpw::kSignature, Gp::kIdBp);
-static constexpr Gp si(Gpw::kSignature, Gp::kIdSi);
-static constexpr Gp di(Gpw::kSignature, Gp::kIdDi);
-static constexpr Gp r8w(Gpw::kSignature, Gp::kIdR8);
-static constexpr Gp r9w(Gpw::kSignature, Gp::kIdR9);
-static constexpr Gp r10w(Gpw::kSignature, Gp::kIdR10);
-static constexpr Gp r11w(Gpw::kSignature, Gp::kIdR11);
-static constexpr Gp r12w(Gpw::kSignature, Gp::kIdR12);
-static constexpr Gp r13w(Gpw::kSignature, Gp::kIdR13);
-static constexpr Gp r14w(Gpw::kSignature, Gp::kIdR14);
-static constexpr Gp r15w(Gpw::kSignature, Gp::kIdR15);
+static ASMJIT_OPERAND_CONSTEXPR Gp ax(Gpw::kSignature, Gp::kIdAx);
+static ASMJIT_OPERAND_CONSTEXPR Gp bx(Gpw::kSignature, Gp::kIdBx);
+static ASMJIT_OPERAND_CONSTEXPR Gp cx(Gpw::kSignature, Gp::kIdCx);
+static ASMJIT_OPERAND_CONSTEXPR Gp dx(Gpw::kSignature, Gp::kIdDx);
+static ASMJIT_OPERAND_CONSTEXPR Gp sp(Gpw::kSignature, Gp::kIdSp);
+static ASMJIT_OPERAND_CONSTEXPR Gp bp(Gpw::kSignature, Gp::kIdBp);
+static ASMJIT_OPERAND_CONSTEXPR Gp si(Gpw::kSignature, Gp::kIdSi);
+static ASMJIT_OPERAND_CONSTEXPR Gp di(Gpw::kSignature, Gp::kIdDi);
+static ASMJIT_OPERAND_CONSTEXPR Gp r8w(Gpw::kSignature, Gp::kIdR8);
+static ASMJIT_OPERAND_CONSTEXPR Gp r9w(Gpw::kSignature, Gp::kIdR9);
+static ASMJIT_OPERAND_CONSTEXPR Gp r10w(Gpw::kSignature, Gp::kIdR10);
+static ASMJIT_OPERAND_CONSTEXPR Gp r11w(Gpw::kSignature, Gp::kIdR11);
+static ASMJIT_OPERAND_CONSTEXPR Gp r12w(Gpw::kSignature, Gp::kIdR12);
+static ASMJIT_OPERAND_CONSTEXPR Gp r13w(Gpw::kSignature, Gp::kIdR13);
+static ASMJIT_OPERAND_CONSTEXPR Gp r14w(Gpw::kSignature, Gp::kIdR14);
+static ASMJIT_OPERAND_CONSTEXPR Gp r15w(Gpw::kSignature, Gp::kIdR15);
 
-static constexpr Gp eax(Gpd::kSignature, Gp::kIdAx);
-static constexpr Gp ebx(Gpd::kSignature, Gp::kIdBx);
-static constexpr Gp ecx(Gpd::kSignature, Gp::kIdCx);
-static constexpr Gp edx(Gpd::kSignature, Gp::kIdDx);
-static constexpr Gp esp(Gpd::kSignature, Gp::kIdSp);
-static constexpr Gp ebp(Gpd::kSignature, Gp::kIdBp);
-static constexpr Gp esi(Gpd::kSignature, Gp::kIdSi);
-static constexpr Gp edi(Gpd::kSignature, Gp::kIdDi);
-static constexpr Gp r8d(Gpd::kSignature, Gp::kIdR8);
-static constexpr Gp r9d(Gpd::kSignature, Gp::kIdR9);
-static constexpr Gp r10d(Gpd::kSignature, Gp::kIdR10);
-static constexpr Gp r11d(Gpd::kSignature, Gp::kIdR11);
-static constexpr Gp r12d(Gpd::kSignature, Gp::kIdR12);
-static constexpr Gp r13d(Gpd::kSignature, Gp::kIdR13);
-static constexpr Gp r14d(Gpd::kSignature, Gp::kIdR14);
-static constexpr Gp r15d(Gpd::kSignature, Gp::kIdR15);
+static ASMJIT_OPERAND_CONSTEXPR Gp eax(Gpd::kSignature, Gp::kIdAx);
+static ASMJIT_OPERAND_CONSTEXPR Gp ebx(Gpd::kSignature, Gp::kIdBx);
+static ASMJIT_OPERAND_CONSTEXPR Gp ecx(Gpd::kSignature, Gp::kIdCx);
+static ASMJIT_OPERAND_CONSTEXPR Gp edx(Gpd::kSignature, Gp::kIdDx);
+static ASMJIT_OPERAND_CONSTEXPR Gp esp(Gpd::kSignature, Gp::kIdSp);
+static ASMJIT_OPERAND_CONSTEXPR Gp ebp(Gpd::kSignature, Gp::kIdBp);
+static ASMJIT_OPERAND_CONSTEXPR Gp esi(Gpd::kSignature, Gp::kIdSi);
+static ASMJIT_OPERAND_CONSTEXPR Gp edi(Gpd::kSignature, Gp::kIdDi);
+static ASMJIT_OPERAND_CONSTEXPR Gp r8d(Gpd::kSignature, Gp::kIdR8);
+static ASMJIT_OPERAND_CONSTEXPR Gp r9d(Gpd::kSignature, Gp::kIdR9);
+static ASMJIT_OPERAND_CONSTEXPR Gp r10d(Gpd::kSignature, Gp::kIdR10);
+static ASMJIT_OPERAND_CONSTEXPR Gp r11d(Gpd::kSignature, Gp::kIdR11);
+static ASMJIT_OPERAND_CONSTEXPR Gp r12d(Gpd::kSignature, Gp::kIdR12);
+static ASMJIT_OPERAND_CONSTEXPR Gp r13d(Gpd::kSignature, Gp::kIdR13);
+static ASMJIT_OPERAND_CONSTEXPR Gp r14d(Gpd::kSignature, Gp::kIdR14);
+static ASMJIT_OPERAND_CONSTEXPR Gp r15d(Gpd::kSignature, Gp::kIdR15);
 
-static constexpr Gp rax(Gpq::kSignature, Gp::kIdAx);
-static constexpr Gp rbx(Gpq::kSignature, Gp::kIdBx);
-static constexpr Gp rcx(Gpq::kSignature, Gp::kIdCx);
-static constexpr Gp rdx(Gpq::kSignature, Gp::kIdDx);
-static constexpr Gp rsp(Gpq::kSignature, Gp::kIdSp);
-static constexpr Gp rbp(Gpq::kSignature, Gp::kIdBp);
-static constexpr Gp rsi(Gpq::kSignature, Gp::kIdSi);
-static constexpr Gp rdi(Gpq::kSignature, Gp::kIdDi);
-static constexpr Gp r8(Gpq::kSignature, Gp::kIdR8);
-static constexpr Gp r9(Gpq::kSignature, Gp::kIdR9);
-static constexpr Gp r10(Gpq::kSignature, Gp::kIdR10);
-static constexpr Gp r11(Gpq::kSignature, Gp::kIdR11);
-static constexpr Gp r12(Gpq::kSignature, Gp::kIdR12);
-static constexpr Gp r13(Gpq::kSignature, Gp::kIdR13);
-static constexpr Gp r14(Gpq::kSignature, Gp::kIdR14);
-static constexpr Gp r15(Gpq::kSignature, Gp::kIdR15);
+static ASMJIT_OPERAND_CONSTEXPR Gp rax(Gpq::kSignature, Gp::kIdAx);
+static ASMJIT_OPERAND_CONSTEXPR Gp rbx(Gpq::kSignature, Gp::kIdBx);
+static ASMJIT_OPERAND_CONSTEXPR Gp rcx(Gpq::kSignature, Gp::kIdCx);
+static ASMJIT_OPERAND_CONSTEXPR Gp rdx(Gpq::kSignature, Gp::kIdDx);
+static ASMJIT_OPERAND_CONSTEXPR Gp rsp(Gpq::kSignature, Gp::kIdSp);
+static ASMJIT_OPERAND_CONSTEXPR Gp rbp(Gpq::kSignature, Gp::kIdBp);
+static ASMJIT_OPERAND_CONSTEXPR Gp rsi(Gpq::kSignature, Gp::kIdSi);
+static ASMJIT_OPERAND_CONSTEXPR Gp rdi(Gpq::kSignature, Gp::kIdDi);
+static ASMJIT_OPERAND_CONSTEXPR Gp r8(Gpq::kSignature, Gp::kIdR8);
+static ASMJIT_OPERAND_CONSTEXPR Gp r9(Gpq::kSignature, Gp::kIdR9);
+static ASMJIT_OPERAND_CONSTEXPR Gp r10(Gpq::kSignature, Gp::kIdR10);
+static ASMJIT_OPERAND_CONSTEXPR Gp r11(Gpq::kSignature, Gp::kIdR11);
+static ASMJIT_OPERAND_CONSTEXPR Gp r12(Gpq::kSignature, Gp::kIdR12);
+static ASMJIT_OPERAND_CONSTEXPR Gp r13(Gpq::kSignature, Gp::kIdR13);
+static ASMJIT_OPERAND_CONSTEXPR Gp r14(Gpq::kSignature, Gp::kIdR14);
+static ASMJIT_OPERAND_CONSTEXPR Gp r15(Gpq::kSignature, Gp::kIdR15);
 
-static constexpr Xmm xmm0(0);
-static constexpr Xmm xmm1(1);
-static constexpr Xmm xmm2(2);
-static constexpr Xmm xmm3(3);
-static constexpr Xmm xmm4(4);
-static constexpr Xmm xmm5(5);
-static constexpr Xmm xmm6(6);
-static constexpr Xmm xmm7(7);
-static constexpr Xmm xmm8(8);
-static constexpr Xmm xmm9(9);
-static constexpr Xmm xmm10(10);
-static constexpr Xmm xmm11(11);
-static constexpr Xmm xmm12(12);
-static constexpr Xmm xmm13(13);
-static constexpr Xmm xmm14(14);
-static constexpr Xmm xmm15(15);
-static constexpr Xmm xmm16(16);
-static constexpr Xmm xmm17(17);
-static constexpr Xmm xmm18(18);
-static constexpr Xmm xmm19(19);
-static constexpr Xmm xmm20(20);
-static constexpr Xmm xmm21(21);
-static constexpr Xmm xmm22(22);
-static constexpr Xmm xmm23(23);
-static constexpr Xmm xmm24(24);
-static constexpr Xmm xmm25(25);
-static constexpr Xmm xmm26(26);
-static constexpr Xmm xmm27(27);
-static constexpr Xmm xmm28(28);
-static constexpr Xmm xmm29(29);
-static constexpr Xmm xmm30(30);
-static constexpr Xmm xmm31(31);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm0(0);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm1(1);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm2(2);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm3(3);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm4(4);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm5(5);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm6(6);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm7(7);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm8(8);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm9(9);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm10(10);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm11(11);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm12(12);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm13(13);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm14(14);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm15(15);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm16(16);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm17(17);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm18(18);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm19(19);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm20(20);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm21(21);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm22(22);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm23(23);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm24(24);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm25(25);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm26(26);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm27(27);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm28(28);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm29(29);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm30(30);
+static ASMJIT_OPERAND_CONSTEXPR Xmm xmm31(31);
 
-static constexpr Ymm ymm0(0);
-static constexpr Ymm ymm1(1);
-static constexpr Ymm ymm2(2);
-static constexpr Ymm ymm3(3);
-static constexpr Ymm ymm4(4);
-static constexpr Ymm ymm5(5);
-static constexpr Ymm ymm6(6);
-static constexpr Ymm ymm7(7);
-static constexpr Ymm ymm8(8);
-static constexpr Ymm ymm9(9);
-static constexpr Ymm ymm10(10);
-static constexpr Ymm ymm11(11);
-static constexpr Ymm ymm12(12);
-static constexpr Ymm ymm13(13);
-static constexpr Ymm ymm14(14);
-static constexpr Ymm ymm15(15);
-static constexpr Ymm ymm16(16);
-static constexpr Ymm ymm17(17);
-static constexpr Ymm ymm18(18);
-static constexpr Ymm ymm19(19);
-static constexpr Ymm ymm20(20);
-static constexpr Ymm ymm21(21);
-static constexpr Ymm ymm22(22);
-static constexpr Ymm ymm23(23);
-static constexpr Ymm ymm24(24);
-static constexpr Ymm ymm25(25);
-static constexpr Ymm ymm26(26);
-static constexpr Ymm ymm27(27);
-static constexpr Ymm ymm28(28);
-static constexpr Ymm ymm29(29);
-static constexpr Ymm ymm30(30);
-static constexpr Ymm ymm31(31);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm0(0);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm1(1);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm2(2);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm3(3);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm4(4);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm5(5);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm6(6);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm7(7);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm8(8);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm9(9);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm10(10);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm11(11);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm12(12);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm13(13);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm14(14);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm15(15);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm16(16);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm17(17);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm18(18);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm19(19);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm20(20);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm21(21);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm22(22);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm23(23);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm24(24);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm25(25);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm26(26);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm27(27);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm28(28);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm29(29);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm30(30);
+static ASMJIT_OPERAND_CONSTEXPR Ymm ymm31(31);
 
-static constexpr Zmm zmm0(0);
-static constexpr Zmm zmm1(1);
-static constexpr Zmm zmm2(2);
-static constexpr Zmm zmm3(3);
-static constexpr Zmm zmm4(4);
-static constexpr Zmm zmm5(5);
-static constexpr Zmm zmm6(6);
-static constexpr Zmm zmm7(7);
-static constexpr Zmm zmm8(8);
-static constexpr Zmm zmm9(9);
-static constexpr Zmm zmm10(10);
-static constexpr Zmm zmm11(11);
-static constexpr Zmm zmm12(12);
-static constexpr Zmm zmm13(13);
-static constexpr Zmm zmm14(14);
-static constexpr Zmm zmm15(15);
-static constexpr Zmm zmm16(16);
-static constexpr Zmm zmm17(17);
-static constexpr Zmm zmm18(18);
-static constexpr Zmm zmm19(19);
-static constexpr Zmm zmm20(20);
-static constexpr Zmm zmm21(21);
-static constexpr Zmm zmm22(22);
-static constexpr Zmm zmm23(23);
-static constexpr Zmm zmm24(24);
-static constexpr Zmm zmm25(25);
-static constexpr Zmm zmm26(26);
-static constexpr Zmm zmm27(27);
-static constexpr Zmm zmm28(28);
-static constexpr Zmm zmm29(29);
-static constexpr Zmm zmm30(30);
-static constexpr Zmm zmm31(31);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm0(0);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm1(1);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm2(2);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm3(3);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm4(4);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm5(5);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm6(6);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm7(7);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm8(8);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm9(9);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm10(10);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm11(11);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm12(12);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm13(13);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm14(14);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm15(15);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm16(16);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm17(17);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm18(18);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm19(19);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm20(20);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm21(21);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm22(22);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm23(23);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm24(24);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm25(25);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm26(26);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm27(27);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm28(28);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm29(29);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm30(30);
+static ASMJIT_OPERAND_CONSTEXPR Zmm zmm31(31);
 
-static constexpr Mm mm0(0);
-static constexpr Mm mm1(1);
-static constexpr Mm mm2(2);
-static constexpr Mm mm3(3);
-static constexpr Mm mm4(4);
-static constexpr Mm mm5(5);
-static constexpr Mm mm6(6);
-static constexpr Mm mm7(7);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm0(0);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm1(1);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm2(2);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm3(3);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm4(4);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm5(5);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm6(6);
+static ASMJIT_OPERAND_CONSTEXPR Mm mm7(7);
 
-static constexpr KReg k0(0);
-static constexpr KReg k1(1);
-static constexpr KReg k2(2);
-static constexpr KReg k3(3);
-static constexpr KReg k4(4);
-static constexpr KReg k5(5);
-static constexpr KReg k6(6);
-static constexpr KReg k7(7);
+static ASMJIT_OPERAND_CONSTEXPR KReg k0(0);
+static ASMJIT_OPERAND_CONSTEXPR KReg k1(1);
+static ASMJIT_OPERAND_CONSTEXPR KReg k2(2);
+static ASMJIT_OPERAND_CONSTEXPR KReg k3(3);
+static ASMJIT_OPERAND_CONSTEXPR KReg k4(4);
+static ASMJIT_OPERAND_CONSTEXPR KReg k5(5);
+static ASMJIT_OPERAND_CONSTEXPR KReg k6(6);
+static ASMJIT_OPERAND_CONSTEXPR KReg k7(7);
 
-static constexpr SReg no_seg(SReg::kIdNone);
-static constexpr SReg es(SReg::kIdEs);
-static constexpr SReg cs(SReg::kIdCs);
-static constexpr SReg ss(SReg::kIdSs);
-static constexpr SReg ds(SReg::kIdDs);
-static constexpr SReg fs(SReg::kIdFs);
-static constexpr SReg gs(SReg::kIdGs);
+static ASMJIT_OPERAND_CONSTEXPR SReg no_seg(SReg::kIdNone);
+static ASMJIT_OPERAND_CONSTEXPR SReg es(SReg::kIdEs);
+static ASMJIT_OPERAND_CONSTEXPR SReg cs(SReg::kIdCs);
+static ASMJIT_OPERAND_CONSTEXPR SReg ss(SReg::kIdSs);
+static ASMJIT_OPERAND_CONSTEXPR SReg ds(SReg::kIdDs);
+static ASMJIT_OPERAND_CONSTEXPR SReg fs(SReg::kIdFs);
+static ASMJIT_OPERAND_CONSTEXPR SReg gs(SReg::kIdGs);
 
-static constexpr CReg cr0(0);
-static constexpr CReg cr1(1);
-static constexpr CReg cr2(2);
-static constexpr CReg cr3(3);
-static constexpr CReg cr4(4);
-static constexpr CReg cr5(5);
-static constexpr CReg cr6(6);
-static constexpr CReg cr7(7);
-static constexpr CReg cr8(8);
-static constexpr CReg cr9(9);
-static constexpr CReg cr10(10);
-static constexpr CReg cr11(11);
-static constexpr CReg cr12(12);
-static constexpr CReg cr13(13);
-static constexpr CReg cr14(14);
-static constexpr CReg cr15(15);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr0(0);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr1(1);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr2(2);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr3(3);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr4(4);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr5(5);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr6(6);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr7(7);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr8(8);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr9(9);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr10(10);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr11(11);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr12(12);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr13(13);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr14(14);
+static ASMJIT_OPERAND_CONSTEXPR CReg cr15(15);
 
-static constexpr DReg dr0(0);
-static constexpr DReg dr1(1);
-static constexpr DReg dr2(2);
-static constexpr DReg dr3(3);
-static constexpr DReg dr4(4);
-static constexpr DReg dr5(5);
-static constexpr DReg dr6(6);
-static constexpr DReg dr7(7);
-static constexpr DReg dr8(8);
-static constexpr DReg dr9(9);
-static constexpr DReg dr10(10);
-static constexpr DReg dr11(11);
-static constexpr DReg dr12(12);
-static constexpr DReg dr13(13);
-static constexpr DReg dr14(14);
-static constexpr DReg dr15(15);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr0(0);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr1(1);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr2(2);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr3(3);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr4(4);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr5(5);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr6(6);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr7(7);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr8(8);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr9(9);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr10(10);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr11(11);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr12(12);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr13(13);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr14(14);
+static ASMJIT_OPERAND_CONSTEXPR DReg dr15(15);
 
-static constexpr St st0(0);
-static constexpr St st1(1);
-static constexpr St st2(2);
-static constexpr St st3(3);
-static constexpr St st4(4);
-static constexpr St st5(5);
-static constexpr St st6(6);
-static constexpr St st7(7);
+static ASMJIT_OPERAND_CONSTEXPR St st0(0);
+static ASMJIT_OPERAND_CONSTEXPR St st1(1);
+static ASMJIT_OPERAND_CONSTEXPR St st2(2);
+static ASMJIT_OPERAND_CONSTEXPR St st3(3);
+static ASMJIT_OPERAND_CONSTEXPR St st4(4);
+static ASMJIT_OPERAND_CONSTEXPR St st5(5);
+static ASMJIT_OPERAND_CONSTEXPR St st6(6);
+static ASMJIT_OPERAND_CONSTEXPR St st7(7);
 
-static constexpr Bnd bnd0(0);
-static constexpr Bnd bnd1(1);
-static constexpr Bnd bnd2(2);
-static constexpr Bnd bnd3(3);
+static ASMJIT_OPERAND_CONSTEXPR Bnd bnd0(0);
+static ASMJIT_OPERAND_CONSTEXPR Bnd bnd1(1);
+static ASMJIT_OPERAND_CONSTEXPR Bnd bnd2(2);
+static ASMJIT_OPERAND_CONSTEXPR Bnd bnd3(3);
 
-static constexpr Rip rip(0);
+static ASMJIT_OPERAND_CONSTEXPR Rip rip(0);
 
 } // {regs}
 
@@ -858,136 +858,136 @@ using namespace regs;
 // ============================================================================
 
 //! Creates `[base.reg + offset]` memory operand.
-static constexpr Mem ptr(const Gp& base, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Gp& base, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, offset, size);
 }
 //! Creates `[base.reg + (index << shift) + offset]` memory operand (scalar index).
-static constexpr Mem ptr(const Gp& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Gp& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, offset, size);
 }
 //! Creates `[base.reg + (index << shift) + offset]` memory operand (vector index).
-static constexpr Mem ptr(const Gp& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Gp& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, offset, size);
 }
 
 //! Creates `[base + offset]` memory operand.
-static constexpr Mem ptr(const Label& base, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Label& base, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, offset, size);
 }
 //! Creates `[base + (index << shift) + offset]` memory operand.
-static constexpr Mem ptr(const Label& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Label& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, offset, size);
 }
 //! Creates `[base + (index << shift) + offset]` memory operand.
-static constexpr Mem ptr(const Label& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Label& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, offset, size);
 }
 
 //! Creates `[rip + offset]` memory operand.
-static constexpr Mem ptr(const Rip& rip_, int32_t offset = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(const Rip& rip_, int32_t offset = 0, uint32_t size = 0) noexcept {
   return Mem(rip_, offset, size);
 }
 
 //! Creates `[base]` absolute memory operand.
-static constexpr Mem ptr(uint64_t base, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(uint64_t base, uint32_t size = 0) noexcept {
   return Mem(base, size);
 }
 //! Creates `[base + (index.reg << shift)]` absolute memory operand.
-static constexpr Mem ptr(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size);
 }
 //! Creates `[base + (index.reg << shift)]` absolute memory operand.
-static constexpr Mem ptr(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size);
 }
 
 //! Creates `[base]` absolute memory operand (absolute).
-static constexpr Mem ptr_abs(uint64_t base, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_abs(uint64_t base, uint32_t size = 0) noexcept {
   return Mem(base, size, BaseMem::kSignatureMemAbs);
 }
 //! Creates `[base + (index.reg << shift)]` absolute memory operand (absolute).
-static constexpr Mem ptr_abs(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_abs(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size, BaseMem::kSignatureMemAbs);
 }
 //! Creates `[base + (index.reg << shift)]` absolute memory operand (absolute).
-static constexpr Mem ptr_abs(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_abs(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size, BaseMem::kSignatureMemAbs);
 }
 
 //! Creates `[base]` relative memory operand (relative).
-static constexpr Mem ptr_rel(uint64_t base, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_rel(uint64_t base, uint32_t size = 0) noexcept {
   return Mem(base, size, BaseMem::kSignatureMemRel);
 }
 //! Creates `[base + (index.reg << shift)]` relative memory operand (relative).
-static constexpr Mem ptr_rel(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_rel(uint64_t base, const Reg& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size, BaseMem::kSignatureMemRel);
 }
 //! Creates `[base + (index.reg << shift)]` relative memory operand (relative).
-static constexpr Mem ptr_rel(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
+static ASMJIT_OPERAND_CONSTEXPR Mem ptr_rel(uint64_t base, const Vec& index, uint32_t shift = 0, uint32_t size = 0) noexcept {
   return Mem(base, index, shift, size, BaseMem::kSignatureMemRel);
 }
 
 #define ASMJIT_MEM_PTR(FUNC, SIZE)                                                    \
   /*! Creates `[base + offset]` memory operand. */                                    \
-  static constexpr Mem FUNC(const Gp& base, int32_t offset = 0) noexcept {            \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Gp& base, int32_t offset = 0) noexcept { \
     return Mem(base, offset, SIZE);                                                   \
   }                                                                                   \
   /*! Creates `[base + (index << shift) + offset]` memory operand. */                 \
-  static constexpr Mem FUNC(const Gp& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Gp& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
     return Mem(base, index, shift, offset, SIZE);                                     \
   }                                                                                   \
   /*! Creates `[base + (vec_index << shift) + offset]` memory operand. */             \
-  static constexpr Mem FUNC(const Gp& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Gp& base, const Vec& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
     return Mem(base, index, shift, offset, SIZE);                                     \
   }                                                                                   \
   /*! Creates `[base + offset]` memory operand. */                                    \
-  static constexpr Mem FUNC(const Label& base, int32_t offset = 0) noexcept {         \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Label& base, int32_t offset = 0) noexcept { \
     return Mem(base, offset, SIZE);                                                   \
   }                                                                                   \
   /*! Creates `[base + (index << shift) + offset]` memory operand. */                 \
-  static constexpr Mem FUNC(const Label& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Label& base, const Gp& index, uint32_t shift = 0, int32_t offset = 0) noexcept { \
     return Mem(base, index, shift, offset, SIZE);                                     \
   }                                                                                   \
   /*! Creates `[rip + offset]` memory operand. */                                     \
-  static constexpr Mem FUNC(const Rip& rip_, int32_t offset = 0) noexcept {           \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(const Rip& rip_, int32_t offset = 0) noexcept { \
     return Mem(rip_, offset, SIZE);                                                   \
   }                                                                                   \
   /*! Creates `[ptr]` memory operand. */                                              \
-  static constexpr Mem FUNC(uint64_t base) noexcept {                                 \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(uint64_t base) noexcept {                  \
     return Mem(base, SIZE);                                                           \
   }                                                                                   \
   /*! Creates `[base + (index << shift) + offset]` memory operand. */                 \
-  static constexpr Mem FUNC(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE);                                             \
   }                                                                                   \
   /*! Creates `[base + (vec_index << shift) + offset]` memory operand. */             \
-  static constexpr Mem FUNC(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE);                                             \
   }                                                                                   \
                                                                                       \
   /*! Creates `[base + offset]` memory operand (absolute). */                         \
-  static constexpr Mem FUNC##_abs(uint64_t base) noexcept {                           \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_abs(uint64_t base) noexcept {            \
     return Mem(base, SIZE, BaseMem::kSignatureMemAbs);                                \
   }                                                                                   \
   /*! Creates `[base + (index << shift) + offset]` memory operand (absolute). */      \
-  static constexpr Mem FUNC##_abs(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_abs(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE, BaseMem::kSignatureMemAbs);                  \
   }                                                                                   \
   /*! Creates `[base + (vec_index << shift) + offset]` memory operand (absolute). */  \
-  static constexpr Mem FUNC##_abs(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_abs(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE, BaseMem::kSignatureMemAbs);                  \
   }                                                                                   \
                                                                                       \
   /*! Creates `[base + offset]` memory operand (relative). */                         \
-  static constexpr Mem FUNC##_rel(uint64_t base) noexcept {                           \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_rel(uint64_t base) noexcept {            \
     return Mem(base, SIZE, BaseMem::kSignatureMemRel);                                \
   }                                                                                   \
   /*! Creates `[base + (index << shift) + offset]` memory operand (relative). */      \
-  static constexpr Mem FUNC##_rel(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_rel(uint64_t base, const Gp& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE, BaseMem::kSignatureMemRel);                  \
   }                                                                                   \
   /*! Creates `[base + (vec_index << shift) + offset]` memory operand (relative). */  \
-  static constexpr Mem FUNC##_rel(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
+  static ASMJIT_OPERAND_CONSTEXPR Mem FUNC##_rel(uint64_t base, const Vec& index, uint32_t shift = 0) noexcept { \
     return Mem(base, index, shift, SIZE, BaseMem::kSignatureMemRel);                  \
   }
 


### PR DESCRIPTION
Unfortunately, I am stuck with Visual Studio 2015 (maybe some other people too) and the `oldstable` branch doesn't work for me (I keep getting an assertion failure in `X86RAPass_patchFuncMem`, `cell != nullptr`). I have read about the compiler bug concerning `constexpr` and unions, but since `constexpr` is mostly an optimization, I think the library should work fine even without it.

So I tried to find all instances of `constexpr` pertaining to a structure that contains a union, and it seems to me these cases are isolated to [operand.h](src/asmjit/core/operand.h) and [x86operand.h](src/asmjit/x86/x86operand.h). So I have replaced these with `ASMJIT_OPERAND_CONSTEXPR`, which is defined to be empty for Visual Studio 2015 and `constexpr` for everything else. So far, this seems to work fine.

However, I understand if you don't want to clutter the code because of one unsupported compiler, so you can just close this if that's the case.