### PR TITLE
FreeBSD: Fix compilation with -Werror

### DIFF
--- a/src/asmjit/core/virtmem.cpp
+++ b/src/asmjit/core/virtmem.cpp
@@ -351,10 +351,12 @@ static ASMJIT_INLINE int VirtMem_appleSpecificMMapFlags(uint32_t flags) {
 }
 #endif
 
+#if !defined(SHM_ANON)
 static const char* VirtMem_getTmpDir() noexcept {
   const char* tmpDir = getenv("TMPDIR");
   return tmpDir ? tmpDir : "/tmp";
 }
+#endif
 
 static Error VirtMem_openAnonymousMemory(int* fd, bool preferTmpOverDevShm) noexcept {
 #if defined(SYS_memfd_create)


### PR DESCRIPTION
VirtMem_getTmpDir is not used when SHM_ANON is defined which is the case
on FreeBSD. This breaks compilation if -Werror is defined.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.org>