### PR TITLE
Fixed ASMJIT_NONCOPYABLE/NONCONSTRUCTIBLE for GCC 11

### DIFF
--- a/src/asmjit/core/api-config.h
+++ b/src/asmjit/core/api-config.h
@@ -514,18 +514,14 @@ namespace asmjit {
 // [asmjit::Build - Globals - Utilities]
 // ============================================================================
 
-#define ASMJIT_NONCOPYABLE(...)                                               \
-  private:                                                                    \
-    __VA_ARGS__(const __VA_ARGS__& other) = delete;                           \
-    __VA_ARGS__& operator=(const __VA_ARGS__& other) = delete;                \
-  public:
+#define ASMJIT_NONCOPYABLE(Type)                                              \
+    Type(const Type& other) = delete;                                         \
+    Type& operator=(const Type& other) = delete;
 
-#define ASMJIT_NONCONSTRUCTIBLE(...)                                          \
-  private:                                                                    \
-    __VA_ARGS__() = delete;                                                   \
-    __VA_ARGS__(const __VA_ARGS__& other) = delete;                           \
-    __VA_ARGS__& operator=(const __VA_ARGS__& other) = delete;                \
-  public:
+#define ASMJIT_NONCONSTRUCTIBLE(Type)                                         \
+    Type() = delete;                                                          \
+    Type(const Type& other) = delete;                                         \
+    Type& operator=(const Type& other) = delete;
 
 // ============================================================================
 // [asmjit::Build - Globals - Cleanup]

--- a/src/asmjit/core/compiler.cpp
+++ b/src/asmjit/core/compiler.cpp
@@ -41,6 +41,7 @@ ASMJIT_BEGIN_NAMESPACE
 
 class GlobalConstPoolPass : public Pass {
   typedef Pass Base;
+public:
   ASMJIT_NONCOPYABLE(GlobalConstPoolPass)
 
   GlobalConstPoolPass() noexcept : Pass("GlobalConstPoolPass") {}

--- a/src/asmjit/core/raassignment_p.h
+++ b/src/asmjit/core/raassignment_p.h
@@ -40,9 +40,9 @@ ASMJIT_BEGIN_NAMESPACE
 // ============================================================================
 
 class RAAssignment {
+public:
   ASMJIT_NONCOPYABLE(RAAssignment)
 
-public:
   enum Ids : uint32_t {
     kPhysNone = 0xFF,
     kWorkNone = RAWorkReg::kIdNone

--- a/src/asmjit/core/radefs_p.h
+++ b/src/asmjit/core/radefs_p.h
@@ -496,7 +496,7 @@ public:
 template<typename T>
 class RALiveSpans {
 public:
-  ASMJIT_NONCOPYABLE(RALiveSpans<T>)
+  ASMJIT_NONCOPYABLE(RALiveSpans)
 
   typedef typename T::DataType DataType;
   ZoneVector<T> _data;

--- a/src/asmjit/core/string.h
+++ b/src/asmjit/core/string.h
@@ -371,7 +371,7 @@ public:
 template<size_t N>
 class StringTmp : public String {
 public:
-  ASMJIT_NONCOPYABLE(StringTmp<N>)
+  ASMJIT_NONCOPYABLE(StringTmp)
 
   //! Embedded data.
   char _embeddedData[Support::alignUp(N + 1, sizeof(size_t))];

--- a/src/asmjit/core/zone.h
+++ b/src/asmjit/core/zone.h
@@ -391,7 +391,7 @@ public:
 template<size_t N>
 class ZoneTmp : public Zone {
 public:
-  ASMJIT_NONCOPYABLE(ZoneTmp<N>)
+  ASMJIT_NONCOPYABLE(ZoneTmp)
 
   //! Temporary storage, embedded after \ref Zone.
   struct Storage {

--- a/src/asmjit/core/zonehash.h
+++ b/src/asmjit/core/zonehash.h
@@ -175,7 +175,7 @@ public:
 template<typename NodeT>
 class ZoneHash : public ZoneHashBase {
 public:
-  ASMJIT_NONCOPYABLE(ZoneHash<NodeT>)
+  ASMJIT_NONCOPYABLE(ZoneHash)
 
   typedef NodeT Node;
 

--- a/src/asmjit/core/zonestack.h
+++ b/src/asmjit/core/zonestack.h
@@ -133,7 +133,7 @@ public:
 template<typename T>
 class ZoneStack : public ZoneStackBase {
 public:
-  ASMJIT_NONCOPYABLE(ZoneStack<T>)
+  ASMJIT_NONCOPYABLE(ZoneStack)
 
   enum : uint32_t {
     kNumBlockItems   = uint32_t((kBlockSize - sizeof(Block)) / sizeof(T)),

--- a/src/asmjit/core/zonevector.h
+++ b/src/asmjit/core/zonevector.h
@@ -143,7 +143,7 @@ public:
 template <typename T>
 class ZoneVector : public ZoneVectorBase {
 public:
-  ASMJIT_NONCOPYABLE(ZoneVector<T>)
+  ASMJIT_NONCOPYABLE(ZoneVector)
 
   // STL compatibility;
   typedef T value_type;


### PR DESCRIPTION
A similar fix is already in the branch oldstable: https://github.com/asmjit/asmjit/pull/320

Additionally, I simplified the macros ASMJIT_NONCOPYABLE/NONCONSTRUCTIBLE. They do not need to be variadic and should create the deleted member functions in the public interface.