### PR TITLE
restrict templated Imm ctor to scalar types

### DIFF
--- a/src/asmjit/core/operand.h
+++ b/src/asmjit/core/operand.h
@@ -1308,11 +1308,11 @@ public:
               Support::unpackU32At0(shift.value()),
               Support::unpackU32At1(shift.value())) {}
 
-  //! Creates a new signed immediate value, assigning the value to `val` and
+  //! Creates a new immediate value, assigning the value to `val` and
   //! an architecture-specific predicate to `predicate`.
   //!
   //! \note Predicate is currently only used by ARM architectures.
-  template<typename T>
+  template<typename T, typename std::enable_if<std::is_scalar<typename std::decay<T>::type>::value, bool>::type = true>
   inline constexpr Imm(const T& val, const uint32_t predicate = 0) noexcept
     : Operand(Globals::Init, kOpImm | (predicate << kSignaturePredicateShift),
               0,

--- a/src/asmjit/core/operand.h
+++ b/src/asmjit/core/operand.h
@@ -1316,8 +1316,8 @@ public:
   inline constexpr Imm(const T& val, const uint32_t predicate = 0) noexcept
     : Operand(Globals::Init, kOpImm | (predicate << kSignaturePredicateShift),
               0,
-              Support::unpackU32At0(int64_t(val)),
-              Support::unpackU32At1(int64_t(val))) {}
+              Support::unpackU32At0(uint64_t(val)),
+              Support::unpackU32At1(uint64_t(val))) {}
 
   inline Imm(const float& val, const uint32_t predicate = 0) noexcept
     : Operand(Globals::Init, kOpImm | (predicate << kSignaturePredicateShift), 0, 0, 0) { setValue(val); }

--- a/src/asmjit/core/support.h
+++ b/src/asmjit/core/support.h
@@ -797,10 +797,8 @@ static constexpr uint32_t bytepack32_4x8(uint32_t a, uint32_t b, uint32_t c, uin
                         : (d | (c << 8) | (b << 16) | (a << 24));
 }
 
-template<typename T>
-static constexpr uint32_t unpackU32At0(T x) noexcept { return ASMJIT_ARCH_LE ? uint32_t(uint64_t(x) & 0xFFFFFFFFu) : uint32_t(uint64_t(x) >> 32); }
-template<typename T>
-static constexpr uint32_t unpackU32At1(T x) noexcept { return ASMJIT_ARCH_BE ? uint32_t(uint64_t(x) & 0xFFFFFFFFu) : uint32_t(uint64_t(x) >> 32); }
+static constexpr uint32_t unpackU32At0(uint64_t x) noexcept { return uint32_t(ASMJIT_ARCH_LE ? x : x >> 32); }
+static constexpr uint32_t unpackU32At1(uint64_t x) noexcept { return uint32_t(ASMJIT_ARCH_BE ? x : x >> 32); }
 
 // ============================================================================
 // [asmjit::Support - Position of byte (in bit-shift)]


### PR DESCRIPTION
The templated Imm ctor does not make much sense for non-scalar types, except arrays which should decay to pointers.  Unrestricted it allows the implicit creation of immediates from any type.

Using enable_if to be C++11 friendly.