### PR TITLE
Fix anonymous labels

### DIFF
--- a/src/asmjit/core/formatter.cpp
+++ b/src/asmjit/core/formatter.cpp
@@ -143,7 +143,7 @@ Error formatLabel(
     }
 
     if (le->type() == LabelType::kAnonymous)
-      ASMJIT_PROPAGATE(sb.append("L%u@", labelId));
+      ASMJIT_PROPAGATE(sb.appendFormat("L%u@", labelId));
     return sb.append(le->name());
   }
   else {


### PR DESCRIPTION
Anonymous labels accidentally called `sb.append` instead of
`sb.appendFormat` which messes up the label's formatting.
Also, choosing `@` as a separator character was unfortunate,
given that `@` is not commonly accepted as part of label
names by assemblers. This commit hence replaces the `@` by
an `_`.