### PR TITLE
Change comment to reflect non-obsolete assembly dump method

### DIFF
--- a/src/asmjit/x86/x86builder.h
+++ b/src/asmjit/x86/x86builder.h
@@ -36,7 +36,8 @@ ASMJIT_BEGIN_SUB_NAMESPACE(x86)
 //! // Small helper function to print the current content of `cb`.
 //! static void dumpCode(BaseBuilder& builder, const char* phase) {
 //!   String sb;
-//!   builder.dump(sb);
+//!   FormatOptions fo;
+//!   Formatter::formatNodeList(sb, fo, &builder);
 //!   printf("%s:\n%s\n", phase, sb.data());
 //! }
 //!


### PR DESCRIPTION
Solves #368 and presumably updates the automated generated documentation from that issue.