### PR TITLE
Fix an instance of -Wdeprecated-copy

### DIFF
--- a/src/asmjit/core/radefs_p.h
+++ b/src/asmjit/core/radefs_p.h
@@ -666,7 +666,7 @@ struct LiveRegData {
   uint32_t id;
 
   inline explicit LiveRegData(uint32_t id = BaseReg::kIdBad) noexcept : id(id) {}
-  inline LiveRegData(const LiveRegData& other) noexcept : id(other.id) {}
+  inline LiveRegData(const LiveRegData& other) noexcept = default;
 
   inline void init(const LiveRegData& other) noexcept { id = other.id; }
 


### PR DESCRIPTION
This was the only place that this is triggered by clang, so just use ` = default`, since that's cleaner.