### PR TITLE
Add support for using large pages within the JitAllocator

### DIFF
--- a/src/asmjit/core/jitallocator.cpp
+++ b/src/asmjit/core/jitallocator.cpp
@@ -521,14 +521,17 @@ static Error JitAllocatorImpl_newBlock(JitAllocatorPrivateImpl* impl, JitAllocat
   if (block != nullptr)
     bitWords = static_cast<BitWord*>(::malloc(size_t(numBitWords) * 2 * sizeof(BitWord)));
 
+  VirtMem::MemoryFlags memoryFlags = VirtMem::MemoryFlags::kAccessRWX;
+  if (Support::test(impl->options, JitAllocatorOptions::kUseLargePages))
+    memoryFlags |= VirtMem::MemoryFlags::kMMapLargePages;
   uint32_t blockFlags = 0;
   if (bitWords != nullptr) {
     if (Support::test(impl->options, JitAllocatorOptions::kUseDualMapping)) {
-      err = VirtMem::allocDualMapping(&virtMem, blockSize, VirtMem::MemoryFlags::kAccessRWX);
+      err = VirtMem::allocDualMapping(&virtMem, blockSize, memoryFlags);
       blockFlags |= JitAllocatorBlock::kFlagDualMapped;
     }
     else {
-      err = VirtMem::alloc(&virtMem.rx, blockSize, VirtMem::MemoryFlags::kAccessRWX);
+      err = VirtMem::alloc(&virtMem.rx, blockSize, memoryFlags);
       virtMem.rw = virtMem.rx;
     }
   }

--- a/src/asmjit/core/jitallocator.h
+++ b/src/asmjit/core/jitallocator.h
@@ -54,6 +54,10 @@ enum class JitAllocatorOptions : uint32_t {
   //! or have all blocks fully occupied.
   kImmediateRelease = 0x00000008u,
 
+  //! Enables the use of large pages for virtual memory allocations to improve iTLB efficiency.  For example, on a
+  //! 64-bit x86, virtual memory allocations might use 2MiB large pages, instead of the 4KiB default pages.
+  kUseLargePages = 0x00000010u,
+
   //! Use a custom fill pattern, must be combined with `kFlagFillUnusedMemory`.
   kCustomFillPattern = 0x10000000u
 };

--- a/src/asmjit/core/virtmem.h
+++ b/src/asmjit/core/virtmem.h
@@ -29,6 +29,8 @@ ASMJIT_API void flushInstructionCache(void* p, size_t size) noexcept;
 struct Info {
   //! Virtual memory page size.
   uint32_t pageSize;
+  //! Virtual memory large page size.
+  uint32_t largePageSize;
   //! Virtual memory page granularity.
   uint32_t pageGranularity;
 };
@@ -116,6 +118,9 @@ enum class MemoryFlags : uint32_t {
   //! use `MAP_SHARED` instead of `MAP_PRIVATE` to ensure that the OS would not apply copy on write on RW page, which
   //! would cause RX page not having the updated content.
   kMapShared = 0x00000100u,
+
+  //! Request that large pages be used for the memory range.
+  kMMapLargePages = 0x00000200u,
 
   //! Not an access flag, only used by `allocDualMapping()` to override the default allocation strategy to always use
   //! a 'tmp' directory instead of "/dev/shm" (on POSIX platforms). Please note that this flag will be ignored if the


### PR DESCRIPTION
This change adds support for using large pages.  The use of large
pages can improve the efficiency of generated code by reducing the
frequency of iTLB misses.

Two modes of operation are supported: an advisory or implicit mode and
and explicit mode.  Options have been added to JitAllocator to enable
either.

The advisory mode naturally aligns allocations to the size of a large
page, signaling to the kernel to promote the allocation to
using large pages.  This mode has been tested on Linux and FreeBSD and
it might work on other operating systems with implicit large pages.

The explicit mode requests large pages using special flags when
allocating shared or anonymous memory.  This mode is only supported on
Linux and requires the user to reserve large pages ahead-of-time by
writing to files in proc(5) or setting kernel flags and rebooting.