### PR TITLE
Hide ARM formatter declarations if the compile flag is not enabled

### DIFF
--- a/src/asmjit/arm/a64formatter.cpp
+++ b/src/asmjit/arm/a64formatter.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Zlib
 
 #include "../core/api-build_p.h"
-#ifndef ASMJIT_NO_LOGGING
+#if !defined(ASMJIT_NO_AARCH64) && !defined(ASMJIT_NO_LOGGING)
 
 #include "../core/misc_p.h"
 #include "../core/support.h"
@@ -295,4 +295,4 @@ ASMJIT_FAVOR_SIZE Error FormatterInternal::formatInstruction(
 
 ASMJIT_END_SUB_NAMESPACE
 
-#endif // !ASMJIT_NO_LOGGING
+#endif // !ASMJIT_NO_AARCH64 && !ASMJIT_NO_LOGGING

--- a/src/asmjit/x86/x86formatter.cpp
+++ b/src/asmjit/x86/x86formatter.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Zlib
 
 #include "../core/api-build_p.h"
-#ifndef ASMJIT_NO_LOGGING
+#if !defined(ASMJIT_NO_X86) && !defined(ASMJIT_NO_LOGGING)
 
 #include "../core/cpuinfo.h"
 #include "../core/misc_p.h"
@@ -961,4 +961,4 @@ ASMJIT_FAVOR_SIZE Error FormatterInternal::formatInstruction(
 
 ASMJIT_END_SUB_NAMESPACE
 
-#endif // !ASMJIT_NO_LOGGING
+#endif // !ASMJIT_NO_X86 && !ASMJIT_NO_LOGGING


### PR DESCRIPTION
This PR is a minor fix. The ARM formatter is currently not properly guarded by the `ASMJIT_NO_AARCH64` macro I believe.