### PR TITLE
[MSVC] workaround mvn macro and detect ARM64

### DIFF
--- a/src/asmjit/arm/a64emitter.h
+++ b/src/asmjit/arm/a64emitter.h
@@ -11,8 +11,10 @@
 #include "../arm/a64instdb.h"
 #include "../arm/a64operand.h"
 
-// Dectect and undef MSVC mvn macro
+// MSVC targeting AArch64 defines a lot of macros without underscores clashing
+// with AArch64 instruction names. We have to workaround until it's fixed in SDK.
 #if defined(_MSC_VER) && defined(mvn)
+  #define ASMJIT_RESTORE_MSVC_AARCH64_MACROS
   #pragma push_macro("mvn")
   #undef mvn
 #endif
@@ -1231,8 +1233,8 @@ class Emitter : public BaseEmitter, public EmitterExplicitT<Emitter> {
 
 ASMJIT_END_SUB_NAMESPACE
 
-// Restore MSVC mvn macro
-#if defined(_MSC_VER)
+// Restore undefined MSVC AArch64 macros.
+#if defined(ASMJIT_RESTORE_MSVC_AARCH64_MACROS)
   #pragma pop_macro("mvn")
 #endif
 

--- a/src/asmjit/arm/a64emitter.h
+++ b/src/asmjit/arm/a64emitter.h
@@ -11,6 +11,12 @@
 #include "../arm/a64instdb.h"
 #include "../arm/a64operand.h"
 
+// Dectect and undef MSVC mvn macro
+#if defined(_MSC_VER) && defined(mvn)
+  #pragma push_macro("mvn")
+  #undef mvn
+#endif
+
 ASMJIT_BEGIN_SUB_NAMESPACE(a64)
 
 #define ASMJIT_INST_0x(NAME, ID) \
@@ -1224,5 +1230,10 @@ class Emitter : public BaseEmitter, public EmitterExplicitT<Emitter> {
 #undef ASMJIT_INST_1cc
 
 ASMJIT_END_SUB_NAMESPACE
+
+// Restore MSVC mvn macro
+#if defined(_MSC_VER)
+  #pragma pop_macro("mvn")
+#endif
 
 #endif // ASMJIT_ARM_A64EMITTER_H_INCLUDED

--- a/src/asmjit/core/api-config.h
+++ b/src/asmjit/core/api-config.h
@@ -172,7 +172,7 @@ namespace asmjit {
   #define ASMJIT_ARCH_X86 0
 #endif
 
-#if defined(__arm64__) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(__arm64__) || defined(__aarch64__)
 # define ASMJIT_ARCH_ARM 64
 #elif defined(_M_ARM) || defined(_M_ARMT) || defined(__arm__) || defined(__thumb__) || defined(__thumb2__)
   #define ASMJIT_ARCH_ARM 32


### PR DESCRIPTION
mvn workaround is only relevant for compilation, people using the emitter would have to deal with it on their own. Since this is already snowflake handling it might be prudent to make an include helper which will contain this and any future `arm64_neon` defines workarounds.