### PR TITLE
Fix breakages that occur when targeting WASM with Emscripten.

### DIFF
--- a/src/asmjit/core/archtraits.cpp
+++ b/src/asmjit/core/archtraits.cpp
@@ -5,6 +5,7 @@
 
 #include "../core/api-build_p.h"
 #include "../core/archtraits.h"
+#include "../core/environment.h"
 #include "../core/misc_p.h"
 
 #if !defined(ASMJIT_NO_X86)

--- a/src/asmjit/core/virtmem.cpp
+++ b/src/asmjit/core/virtmem.cpp
@@ -852,7 +852,7 @@ Error releaseDualMapping(DualMapping* dm, size_t size) noexcept {
 // ========================================
 
 void flushInstructionCache(void* p, size_t size) noexcept {
-#if ASMJIT_ARCH_X86
+#if ASMJIT_ARCH_X86 || defined(__EMSCRIPTEN__)
   // X86/X86_64 architecture doesn't require to do anything to flush instruction cache.
   DebugUtils::unused(p, size);
 #elif defined(__APPLE__)


### PR DESCRIPTION
I recently had the change to retarget my app built on Blend2D to WASM as an experiment.  It went nearly flawlessly minus two minor errors in asmjit, which this pull request fixes.

We don't import either architecture in archtraits so include environment.h to ensure Environment is visible, and don't use __builtin__clear_cache in Emscripten because it's unsupported.