### PR TITLE
Fix repeated-word typos

### DIFF
--- a/src/asmjit/core.h
+++ b/src/asmjit/core.h
@@ -787,7 +787,7 @@ namespace asmjit {
 //!
 //! There is no function that would return the number of unbound labels as this is completely unimportant from
 //! CodeHolder's perspective. If a label is not used then it doesn't matter whether it's bound or not, only actually
-//! used labels matter. After a Label is bound it's possible to query its offset offset relative to the start of the
+//! used labels matter. After a Label is bound it's possible to query its offset relative to the start of the
 //! section where it was bound:
 //!
 //! ```

--- a/src/asmjit/core/jitallocator.h
+++ b/src/asmjit/core/jitallocator.h
@@ -535,7 +535,7 @@ public:
     ASMJIT_INLINE_NODEBUG size_t usedSize() const noexcept { return _usedSize; }
     //! Returns the number of bytes unused by the allocator at the moment.
     ASMJIT_INLINE_NODEBUG size_t unusedSize() const noexcept { return _reservedSize - _usedSize; }
-    //! Returns the total number of bytes bytes reserved by the allocator (sum of sizes of all blocks).
+    //! Returns the total number of bytes reserved by the allocator (sum of sizes of all blocks).
     ASMJIT_INLINE_NODEBUG size_t reservedSize() const noexcept { return _reservedSize; }
     //! Returns the number of bytes the allocator needs to manage the allocated memory.
     ASMJIT_INLINE_NODEBUG size_t overheadSize() const noexcept { return _overheadSize; }

--- a/src/asmjit/core/virtmem.h
+++ b/src/asmjit/core/virtmem.h
@@ -239,7 +239,7 @@ enum class ProtectJitAccess : uint32_t {
 
 //! Protects access of memory mapped with MAP_JIT flag for the current thread.
 //!
-//! \note This feature is only available on Apple hardware (AArch64) at the moment and and uses a non-portable
+//! \note This feature is only available on Apple hardware (AArch64) at the moment and uses a non-portable
 //! `pthread_jit_write_protect_np()` call when available.
 //!
 //! This function must be called before and after a memory mapped with MAP_JIT flag is modified. Example:

--- a/src/asmjit/x86/x86opcode_p.h
+++ b/src/asmjit/x86/x86opcode_p.h
@@ -45,7 +45,7 @@ struct Opcode {
   //!   `pp` in instruction manuals.
   //!
   //! - `LL` field is used exclusively by AVX+ and AVX512+ instruction sets. It describes vector size, which is `L.128`
-  //!   for XMM register, `L.256` for for YMM register, and `L.512` for ZMM register. The `LL` field is omitted in case
+  //!   for XMM register, `L.256` for YMM register, and `L.512` for ZMM register. The `LL` field is omitted in case
   //!   that instruction supports multiple vector lengths, however, if the instruction requires specific `L` value it
   //!   must be specified as a part of the opcode.
   //!
@@ -244,7 +244,7 @@ struct Opcode {
     // REX|VEX|EVEX B|X|R|W Bits
     // -------------------------
     //
-    // NOTE: REX.[B|X|R] are never stored within the opcode itself, they are reserved by AsmJit are are added
+    // NOTE: REX.[B|X|R] are never stored within the opcode itself, they are reserved by AsmJit and are added
     // dynamically to the opcode to represent [REX|VEX|EVEX].[B|X|R] bits. REX.W can be stored in DB as it's sometimes
     // part of the opcode itself.
 
@@ -280,7 +280,7 @@ struct Opcode {
     // `L` or `LL` field in AVX/XOP/AVX-512
     // ------------------------------------
     //
-    // VEX/XOP prefix can only use the first bit `L.128` or `L.256`. EVEX prefix prefix makes it possible to use also
+    // VEX/XOP prefix can only use the first bit `L.128` or `L.256`. EVEX prefix makes it possible to use also
     // `L.512`. If the instruction set manual describes an instruction by `LIG` it means that the `L` field is ignored
     // and AsmJit defaults to `0` in such case.
     kLL_Shift      = 29,

--- a/src/asmjit/x86/x86operand.h
+++ b/src/asmjit/x86/x86operand.h
@@ -843,7 +843,7 @@ public:
   //!
   //! \note Most instructions would deduce the size of the memory operand, so in most cases it's expected that the
   //! returned value would be zero. However, some instruction require the size to select between multiple variations,
-  //! so in some cases size is required would would be non-zero (for example `inc [mem], immediate` requires size to
+  //! so in some cases size is required would be non-zero (for example `inc [mem], immediate` requires size to
   //! distinguish between 8-bit, 16-bit, 32-bit, and 64-bit increments.
   ASMJIT_INLINE_NODEBUG constexpr uint32_t size() const noexcept { return _signature.getField<Signature::kSizeMask>(); }
 


### PR DESCRIPTION
Hey there, here are some double word typos that I found while removing similar typos in a downstream project (erlang/otp).