### PR TITLE
Since `Inst` is never instantiated, it may be better as a namespace

### DIFF
--- a/src/asmjit/arm/a64globals.h
+++ b/src/asmjit/arm/a64globals.h
@@ -21,7 +21,7 @@ ASMJIT_BEGIN_SUB_NAMESPACE(a64)
 //! AArch64 instruction.
 //!
 //! \note Only used to hold ARM-specific enumerations and static functions.
-struct Inst {
+namespace Inst {
   //! Instruction id.
   enum Id : uint32_t {
     // ${InstId:Begin}


### PR DESCRIPTION
I think `Inst` is better as a namespace since this is more accurate than a struct that is neve instantiated. Since its usage is like `Inst::kIdAdd`, actually I thought it was a namespace until I read its definition.