### PR TITLE
Fix non-virtual destructor message.

### DIFF
--- a/src/asmjit/core/emithelper_p.h
+++ b/src/asmjit/core/emithelper_p.h
@@ -24,6 +24,8 @@ public:
   ASMJIT_INLINE_NODEBUG explicit BaseEmitHelper(BaseEmitter* emitter = nullptr) noexcept
     : _emitter(emitter) {}
 
+  virtual ~BaseEmitHelper() {}
+
   ASMJIT_INLINE_NODEBUG BaseEmitter* emitter() const noexcept { return _emitter; }
   ASMJIT_INLINE_NODEBUG void setEmitter(BaseEmitter* emitter) noexcept { _emitter = emitter; }
 


### PR DESCRIPTION
When we (the Hermes team) compile asmjit in our build, we get warnings (from Clang) like:
```
/Users/ddetlefs/fbsource/xplat/static_h/external/asmjit/asmjit/src/asmjit/core/../core/emithelper_p.h:20:7: warning: 'asmjit::BaseEmitHelper' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
   20 | class BaseEmitHelper {
      |       ^
1 warning generated.
```

This is a potentially serious error; if a subclass were allocated, but destructed at a place where the static type of the pointer is the superclass, the subclass dtor would not be executed.

This probably isn't happening, since things work.  But still, it good hygiene to just do what the error message asks for, and give the base class a virtual dtor.