### PR TITLE
Make ASMJIT_INLINE_NODEBUG consistent with ASMJIT_FORCE_INLINE for debug builds

### DIFF
--- a/src/asmjit/core/api-config.h
+++ b/src/asmjit/core/api-config.h
@@ -379,9 +379,9 @@ namespace asmjit {
 #endif
 
 
-#if defined(__clang__)
+#if !defined(ASMJIT_BUILD_DEBUG) && defined(__clang__)
   #define ASMJIT_INLINE_NODEBUG inline __attribute__((__always_inline__, __nodebug__))
-#elif defined(__GNUC__)
+#elif !defined(ASMJIT_BUILD_DEBUG) && defined(__GNUC__)
   #define ASMJIT_INLINE_NODEBUG inline __attribute__((__always_inline__, __artificial__))
 #else
   #define ASMJIT_INLINE_NODEBUG inline


### PR DESCRIPTION
This patch modifies `ASMJIT_INLINE_NODEBUG` to only apply its compiler-specific attributes in non-debug builds, matching the behavior of `ASMJIT_FORCE_INLINE`.

P.S. This was helpful while debugging code generation, as some functions couldn't be evaluated in gdb due to inlining.