### PR TITLE
Add support for marking registers as unavailable in FuncFrame

### DIFF
--- a/src/asmjit/arm/a64rapass.cpp
+++ b/src/asmjit/arm/a64rapass.cpp
@@ -665,21 +665,9 @@ void ARMRAPass::onInit() noexcept {
   if (hasFP || cc()->environment().isDarwin()) {
     makeUnavailable(RegGroup::kGp, Gp::kIdFp);
   }
-
-  // Initialize WorkData::workRegs.
-  for (RegGroup group : RegGroupVirtValues{}) {
-    // Exclude all user-reserved general-purpose registers from use.
-    RegMask unavailableRegs = frame.unavailableRegs(group);
-    if (unavailableRegs != 0) {
-      for (uint32_t regId = 0; regId < 32; ++regId) {
-        if (Support::bitTest(unavailableRegs, regId))
-          makeUnavailable(group, regId);
-      }
-    }
-  }
-
   makeUnavailable(RegGroup::kGp, Gp::kIdSp);
   makeUnavailable(RegGroup::kGp, Gp::kIdOs); // OS-specific use, usually TLS.
+  makeUnavailable(frame._unavailableRegs);
 
   _sp = sp;
   _fp = x29;

--- a/src/asmjit/core/func.h
+++ b/src/asmjit/core/func.h
@@ -1194,6 +1194,8 @@ public:
   RegMasks _dirtyRegs {};
   //! Registers that must be preserved (copied from CallConv).
   RegMasks _preservedRegs {};
+  //! Registers that are unavailable.
+  RegMasks _unavailableRegs = {};
   //! Size to save/restore per register group.
   Support::Array<uint8_t, Globals::kNumVirtGroups> _saveRestoreRegSize {};
   //! Alignment of save/restore area per register group.
@@ -1564,6 +1566,58 @@ public:
   inline RegMask preservedRegs(RegGroup group) const noexcept {
     ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
     return _preservedRegs[group];
+  }
+
+  //! Sets which registers (as a mask) are unavailable for allocation.
+  //!
+  //! \note This completely overwrites the current unavailable mask.
+  ASMJIT_INLINE_NODEBUG void setUnavailableRegs(RegGroup group, RegMask regs) noexcept {
+    ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
+    _unavailableRegs[group] = regs;
+  }
+
+  //! Adds registers (as a mask) to the unavailable set.
+  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(RegGroup group, RegMask regs) noexcept {
+    ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
+    _unavailableRegs[group] |= regs;
+  }
+
+  //! Adds a single register to the unavailable set.
+  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(const BaseReg& reg) noexcept {
+    ASMJIT_ASSERT(reg.id() < Globals::kMaxPhysRegs);
+    addUnavailableRegs(reg.group(), Support::bitMask(reg.id()));
+  }
+
+  //! Adds multiple registers to the unavailable set.
+  template<typename... Args>
+  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(const BaseReg& reg, Args&&... args) noexcept {
+    addUnavailableRegs(reg);
+    addUnavailableRegs(std::forward<Args>(args)...);
+  }
+
+  //! Clears all unavailable registers across all register groups (i.e., makes them all available again).
+  ASMJIT_INLINE_NODEBUG void makeAllRegsAvailable() noexcept {
+    for (size_t i = 0; i < ASMJIT_ARRAY_SIZE(_unavailableRegs); i++)
+      _unavailableRegs[i] = 0;
+  }
+
+  //! Clears all unavailable registers in a specific register group.
+  ASMJIT_INLINE_NODEBUG void makeAllRegsAvailable(RegGroup group) noexcept {
+    ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
+    _unavailableRegs[group] = 0;
+  }
+
+  //! Returns the set of unavailable registers for the given group.
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG RegMask unavailableRegs(RegGroup group) const noexcept {
+    ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
+    return _unavailableRegs[group];
+  }
+
+  //! Returns all unavailable registers as a Support::Array<>.
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG const RegMasks& unavailableRegs() const noexcept {
+    return _unavailableRegs;
   }
 
   //! Returns the size of a save-restore are for the required register `group`.

--- a/src/asmjit/core/func.h
+++ b/src/asmjit/core/func.h
@@ -1195,7 +1195,7 @@ public:
   //! Registers that must be preserved (copied from CallConv).
   RegMasks _preservedRegs {};
   //! Registers that are unavailable.
-  RegMasks _unavailableRegs = {};
+  RegMasks _unavailableRegs {};
   //! Size to save/restore per register group.
   Support::Array<uint8_t, Globals::kNumVirtGroups> _saveRestoreRegSize {};
   //! Alignment of save/restore area per register group.
@@ -1571,45 +1571,45 @@ public:
   //! Sets which registers (as a mask) are unavailable for allocation.
   //!
   //! \note This completely overwrites the current unavailable mask.
-  ASMJIT_INLINE_NODEBUG void setUnavailableRegs(RegGroup group, RegMask regs) noexcept {
+  inline void setUnavailableRegs(RegGroup group, RegMask regs) noexcept {
     ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
     _unavailableRegs[group] = regs;
   }
 
   //! Adds registers (as a mask) to the unavailable set.
-  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(RegGroup group, RegMask regs) noexcept {
+  inline void addUnavailableRegs(RegGroup group, RegMask regs) noexcept {
     ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
     _unavailableRegs[group] |= regs;
   }
 
   //! Adds a single register to the unavailable set.
-  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(const BaseReg& reg) noexcept {
+  inline void addUnavailableRegs(const BaseReg& reg) noexcept {
     ASMJIT_ASSERT(reg.id() < Globals::kMaxPhysRegs);
     addUnavailableRegs(reg.group(), Support::bitMask(reg.id()));
   }
 
   //! Adds multiple registers to the unavailable set.
   template<typename... Args>
-  ASMJIT_INLINE_NODEBUG void addUnavailableRegs(const BaseReg& reg, Args&&... args) noexcept {
+  inline void addUnavailableRegs(const BaseReg& reg, Args&&... args) noexcept {
     addUnavailableRegs(reg);
     addUnavailableRegs(std::forward<Args>(args)...);
   }
 
   //! Clears all unavailable registers across all register groups (i.e., makes them all available again).
-  ASMJIT_INLINE_NODEBUG void makeAllRegsAvailable() noexcept {
+  ASMJIT_INLINE_NODEBUG void clearUnavailableRegs() noexcept {
     for (size_t i = 0; i < ASMJIT_ARRAY_SIZE(_unavailableRegs); i++)
       _unavailableRegs[i] = 0;
   }
 
   //! Clears all unavailable registers in a specific register group.
-  ASMJIT_INLINE_NODEBUG void makeAllRegsAvailable(RegGroup group) noexcept {
+  inline void clearUnavailableRegs(RegGroup group) noexcept {
     ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
     _unavailableRegs[group] = 0;
   }
 
   //! Returns the set of unavailable registers for the given group.
   [[nodiscard]]
-  ASMJIT_INLINE_NODEBUG RegMask unavailableRegs(RegGroup group) const noexcept {
+  inline RegMask unavailableRegs(RegGroup group) const noexcept {
     ASMJIT_ASSERT(group <= RegGroup::kMaxVirt);
     return _unavailableRegs[group];
   }

--- a/src/asmjit/x86/x86rapass.cpp
+++ b/src/asmjit/x86/x86rapass.cpp
@@ -1309,18 +1309,7 @@ void X86RAPass::onInit() noexcept {
   if (hasFP) {
     makeUnavailable(RegGroup::kGp, Gp::kIdBp); // EBP|RBP used as a frame-pointer (FP).
   }
-
-  // Initialize WorkData::workRegs.
-  for (RegGroup group : RegGroupVirtValues{}) {
-    // Exclude all user-reserved general-purpose registers from use.
-    RegMask unavailableRegs = frame.unavailableRegs(group);
-    if (unavailableRegs != 0) {
-      for (uint32_t regId = 0; regId < 32; ++regId) {
-        if (Support::bitTest(unavailableRegs, regId))
-          makeUnavailable(group, regId);
-      }
-    }
-  }
+  makeUnavailable(frame._unavailableRegs);
 
   _sp = cc()->zsp();
   _fp = cc()->zbp();


### PR DESCRIPTION
This patch introduces support for marking registers as
unavailable for register use by the FuncFrame class.

A new internal bitmask records which registers
ought to be reserved from use. That is useful for platform-specific calling conventions or user-defined constraints — e.g., when a register like X8 is used for special purpose (indirect return, syscall ABI, etc).

**Note**: I also have a second, simpler patch that simply does not use the X8 register
from allocation by a static flag (e.g., `hasReservedX8`). If this abstract
version would be too heavy or too abstract, I can resubmit that one instead for easier
integration.