### PR TITLE
Remove extra semicolons

### DIFF
--- a/src/asmjit/arm/a64globals.h
+++ b/src/asmjit/arm/a64globals.h
@@ -807,7 +807,7 @@ namespace Inst {
 
   //! Tests whether the `instId` is defined (counts also Inst::kIdNone, which must be zero).
   static ASMJIT_INLINE_NODEBUG bool isDefinedId(InstId instId) noexcept { return (instId & uint32_t(InstIdParts::kRealId)) < _kIdCount; }
-};
+}
 
 namespace Predicate {
 
@@ -1089,7 +1089,7 @@ namespace PState {
     kSSBS    = encode(0b011, 0b001),
     kTCO     = encode(0b011, 0b100)
   };
-};
+}
 
 //! System register identifiers and utilities (MSR/MRS).
 namespace SysReg {
@@ -1906,7 +1906,7 @@ namespace SysReg {
     kZCR_EL2              = encode(0b11, 0b100, 0b0001, 0b0010, 0b000), // RW
     kZCR_EL3              = encode(0b11, 0b110, 0b0001, 0b0010, 0b000)  // RW
   };
-};
+}
 
 } // {Predicate}
 

--- a/src/asmjit/core/type.h
+++ b/src/asmjit/core/type.h
@@ -484,23 +484,23 @@ namespace TypeUtils {                                             \
   };                                                              \
 }
 
-ASMJIT_DEFINE_TYPE_ID(void         , TypeId::kVoid);
-ASMJIT_DEFINE_TYPE_ID(Type::Bool   , TypeId::kUInt8);
-ASMJIT_DEFINE_TYPE_ID(Type::Int8   , TypeId::kInt8);
-ASMJIT_DEFINE_TYPE_ID(Type::UInt8  , TypeId::kUInt8);
-ASMJIT_DEFINE_TYPE_ID(Type::Int16  , TypeId::kInt16);
-ASMJIT_DEFINE_TYPE_ID(Type::UInt16 , TypeId::kUInt16);
-ASMJIT_DEFINE_TYPE_ID(Type::Int32  , TypeId::kInt32);
-ASMJIT_DEFINE_TYPE_ID(Type::UInt32 , TypeId::kUInt32);
-ASMJIT_DEFINE_TYPE_ID(Type::Int64  , TypeId::kInt64);
-ASMJIT_DEFINE_TYPE_ID(Type::UInt64 , TypeId::kUInt64);
-ASMJIT_DEFINE_TYPE_ID(Type::IntPtr , TypeId::kIntPtr);
-ASMJIT_DEFINE_TYPE_ID(Type::UIntPtr, TypeId::kUIntPtr);
-ASMJIT_DEFINE_TYPE_ID(Type::Float32, TypeId::kFloat32);
-ASMJIT_DEFINE_TYPE_ID(Type::Float64, TypeId::kFloat64);
-ASMJIT_DEFINE_TYPE_ID(Type::Vec128 , TypeId::kInt32x4);
-ASMJIT_DEFINE_TYPE_ID(Type::Vec256 , TypeId::kInt32x8);
-ASMJIT_DEFINE_TYPE_ID(Type::Vec512 , TypeId::kInt32x16);
+ASMJIT_DEFINE_TYPE_ID(void         , TypeId::kVoid)
+ASMJIT_DEFINE_TYPE_ID(Type::Bool   , TypeId::kUInt8)
+ASMJIT_DEFINE_TYPE_ID(Type::Int8   , TypeId::kInt8)
+ASMJIT_DEFINE_TYPE_ID(Type::UInt8  , TypeId::kUInt8)
+ASMJIT_DEFINE_TYPE_ID(Type::Int16  , TypeId::kInt16)
+ASMJIT_DEFINE_TYPE_ID(Type::UInt16 , TypeId::kUInt16)
+ASMJIT_DEFINE_TYPE_ID(Type::Int32  , TypeId::kInt32)
+ASMJIT_DEFINE_TYPE_ID(Type::UInt32 , TypeId::kUInt32)
+ASMJIT_DEFINE_TYPE_ID(Type::Int64  , TypeId::kInt64)
+ASMJIT_DEFINE_TYPE_ID(Type::UInt64 , TypeId::kUInt64)
+ASMJIT_DEFINE_TYPE_ID(Type::IntPtr , TypeId::kIntPtr)
+ASMJIT_DEFINE_TYPE_ID(Type::UIntPtr, TypeId::kUIntPtr)
+ASMJIT_DEFINE_TYPE_ID(Type::Float32, TypeId::kFloat32)
+ASMJIT_DEFINE_TYPE_ID(Type::Float64, TypeId::kFloat64)
+ASMJIT_DEFINE_TYPE_ID(Type::Vec128 , TypeId::kInt32x4)
+ASMJIT_DEFINE_TYPE_ID(Type::Vec256 , TypeId::kInt32x8)
+ASMJIT_DEFINE_TYPE_ID(Type::Vec512 , TypeId::kInt32x16)
 
 #undef ASMJIT_DEFINE_TYPE_ID
 //! \endcond

--- a/src/asmjit/core/zonevector.cpp
+++ b/src/asmjit/core/zonevector.cpp
@@ -70,7 +70,7 @@ static ASMJIT_INLINE bool ZoneVector_byteSizeIsSafe(size_t nBytes, uint32_t n) n
   else {
     return nBytes >= size_t(n);
   }
-};
+}
 
 Error ZoneVectorBase::_grow(ZoneAllocator* allocator, uint32_t sizeOfT, uint32_t n) noexcept {
   uint32_t capacity = _capacity;


### PR DESCRIPTION
To fix Clang warnings of "Wc++98-compat-extra-semi"