### PR TITLE
Install missing header: core/span.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,6 +478,7 @@ set(ASMJIT_SRC_LIST
   asmjit/core/rapass_p.h
   asmjit/core/rastack.cpp
   asmjit/core/rastack_p.h
+  asmjit/core/span.h
   asmjit/core/string.cpp
   asmjit/core/string.h
   asmjit/core/support.cpp


### PR DESCRIPTION
The header is included by several others. The header was added by 7596c6d, but was missing from the list of target's sources and hence wasn't been installed by `make install`.