### PR TITLE
fix AArch64 fmov encoding bug

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler_a64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_a64.cpp
@@ -1907,6 +1907,10 @@ static void ASMJIT_NOINLINE test_aarch64_assembler_simd(AssemblerTester<a64::Ass
   TEST_INSTRUCTION("01F4034F", fmov(v1.s4(), 0.5));
   TEST_INSTRUCTION("01F4004F", fmov(v1.s4(), 2.0));
   TEST_INSTRUCTION("01F4036F", fmov(v1.d2(), 0.5));
+  TEST_INSTRUCTION("00F4030F", fmov(v0.s2(), 0.5));
+  TEST_INSTRUCTION("00F4000F", fmov(v0.s2(), 2.0));
+  TEST_INSTRUCTION("00F4034F", fmov(v0.s4(), 0.5));
+  TEST_INSTRUCTION("00F4004F", fmov(v0.s4(), 2.0));
   TEST_INSTRUCTION("01F4006F", fmov(v1.d2(), 2.0));
   TEST_INSTRUCTION("4190C31F", fmsub(h1, h2, h3, h4));
   TEST_INSTRUCTION("4190031F", fmsub(s1, s2, s3, s4));

--- a/asmjit/arm/a64assembler.cpp
+++ b/asmjit/arm/a64assembler.cpp
@@ -3580,7 +3580,7 @@ Case_BaseLdurStur:
             if (q > 1 || sz > 2)
               goto InvalidInstruction;
 
-            static const uint32_t sz_bits_table[3] = { B(11), B(0), B(29) };
+            static const uint32_t sz_bits_table[3] = { B(11), 0, B(29) };
             opcode.reset(0b00001111000000001111010000000000);
             opcode ^= sz_bits_table[sz];
             opcode.add_imm(q, 30);


### PR DESCRIPTION
Encoding of [vector + imm](https://www.scs.stanford.edu/~zyedidia/arm64/fmov_advsimd.html) `fmov` instruction in AArch64   is incorrect when several conditions are met:
1. Single precision vector register addressing mode - `.4s` or  `.2s`
2. Even-numbered register, such as `v0.4s` or `v2.4s`

In such cases resulting machine code addresses (n+1) register, for example `v1.4s` instead of `v0.4s`.
It was caused by incorrect xor in `fmov` assembler code. It set to 1 first bit of instruction, which encodes register number. 

I got these results in tests with even-numbered registers (first byte should be same as register number):
![telegram-cloud-photo-size-2-5312491069456977695-x](https://github.com/user-attachments/assets/2b3892bd-f7fe-43ee-ba1a-f38e2761960d)
