### PR TITLE
AArch64 relative branching selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,13 @@ else()
         CFLAGS_REL ${ASMJIT_PRIVATE_CFLAGS_REL})
     endforeach()
 
+    asmjit_add_target(asmjit_test_assembler_a64_veneers TEST
+      SOURCES    asmjit-testing/tests/asmjit_test_assembler_a64_veneers.cpp
+      LIBRARIES  asmjit::asmjit
+      CFLAGS     ${ASMJIT_PRIVATE_CFLAGS}
+      CFLAGS_DBG ${ASMJIT_PRIVATE_CFLAGS_DBG}
+      CFLAGS_REL ${ASMJIT_PRIVATE_CFLAGS_REL})
+
     if (NOT ASMJIT_NO_INTROSPECTION)
       asmjit_add_target(asmjit_test_instinfo TEST
         SOURCES    asmjit-testing/tests/asmjit_test_instinfo.cpp

--- a/asmjit-testing/tests/asmjit_test_assembler_a64_veneers.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_a64_veneers.cpp
@@ -1,0 +1,191 @@
+// This file is part of AsmJit project <https://asmjit.com>
+//
+// See <asmjit/core.h> or LICENSE.md for license and copyright information
+// SPDX-License-Identifier: Zlib
+
+// ----------------------------------------------------------------------------
+// This test demonstrates AArch64 address entry functionality, which allows
+// branch instructions (b and bl) to use an address table when the target
+// is out of range for a direct branch (±128MB).
+// ----------------------------------------------------------------------------
+
+#include <asmjit/core.h>
+#if ASMJIT_ARCH_ARM >= ASMJIT_ARCH_ARM64 && !defined(ASMJIT_NO_AARCH64) && !defined(ASMJIT_NO_JIT)
+
+#include <asmjit/a64.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+using namespace asmjit;
+
+static void fail(const char* message, Error err) {
+  printf("** FAILURE: %s (%s) **\n", message, DebugUtils::error_as_string(err));
+  exit(1);
+}
+
+int main() {
+  printf("AsmJit AArch64 Address Entry Test\n\n");
+
+  Environment env = Environment::host();
+  JitAllocator allocator;
+
+#ifndef ASMJIT_NO_LOGGING
+  FileLogger logger(stdout);
+  logger.set_indentation(FormatIndentationGroup::kCode, 2);
+#endif
+
+  CodeHolder code;
+  code.init(env);
+
+#ifndef ASMJIT_NO_LOGGING
+  code.set_logger(&logger);
+#endif
+
+  printf("Generating code:\n");
+  a64::Assembler a(&code);
+
+  // Create a simple function that branches to an absolute address
+  // This simulates a far branch that would be out of range
+  FuncDetail func;
+  func.init(FuncSignature::build<int>(), code.environment());
+
+  FuncFrame frame;
+  frame.init(func);
+
+  a.emit_prolog(frame);
+
+  // Use addresses far enough apart to force veneer creation
+  // Direct branch range is ±128MB (0x8000000 bytes)
+  // We'll use an address 256MB away to guarantee veneer creation
+  uint64_t far_address = 0x0000100000000000ULL;  // 256MB away
+
+  // Create a label for the return path
+  Label ret_label = a.new_label();
+
+  // Test 1: Branch with link to far address (should use veneer+address table)
+  a.bl(Imm(far_address));
+
+  // Bind return label
+  a.bind(ret_label);
+
+  // Return 42 as test value
+  a.mov(a64::w0, 42);
+
+  a.emit_epilog(frame);
+
+  // Flatten the code to assign section offsets
+  printf("\nFlattening code:\n");
+  Error err = code.flatten();
+  if (err != Error::kOk)
+    fail("Failed to flatten code", err);
+
+  // Print section information BEFORE relocation
+  printf("Sections (before relocation):\n");
+  for (Section* section : code.sections_by_order()) {
+    printf("  [0x%08X %s] {Id=%u Size=%u}\n",
+           uint32_t(section->offset()),
+           section->name(),
+           section->section_id(),
+           uint32_t(section->real_size()));
+  }
+
+  size_t code_size = code.code_size();
+  printf("  Final code size: %zu\n", code_size);
+
+  // Resolve cross-section fixups if any
+  if (code.has_unresolved_fixups()) {
+    printf("\nResolving cross-section fixups:\n");
+    printf("  Before: %zu\n", code.unresolved_fixup_count());
+
+    err = code.resolve_cross_section_fixups();
+    if (err != Error::kOk)
+      fail("Failed to resolve cross-section fixups", err);
+
+    printf("  After: %zu\n", code.unresolved_fixup_count());
+  }
+
+  // Check if address table section was created
+  if (code.has_address_table_section()) {
+    Section* addrtab = code.address_table_section();
+    printf("\nAddress table section created:\n");
+    printf("  Offset: 0x%08X\n", uint32_t(addrtab->offset()));
+    printf("  Size: %u\n", uint32_t(addrtab->real_size()));
+  }
+
+  // Allocate memory for the function and relocate it there
+  JitAllocator::Span span;
+  err = allocator.alloc(Out(span), code_size);
+  if (err != Error::kOk)
+    fail("Failed to allocate executable memory", err);
+
+  // Use a base address that's far from our target to force veneer creation
+  // We'll use a base address near 0 so that our far_address (256MB away) requires a veneer
+  uint64_t base_address = 0x0000000000100000ULL;  // Low address
+
+  printf("\nRelocating to base address: 0x%llX\n", (unsigned long long)base_address);
+  printf("  Target branch address: 0x%llX\n", (unsigned long long)far_address);
+  printf("  Distance: 0x%llX bytes (%.1f MB)\n",
+         (unsigned long long)(far_address - base_address),
+         (far_address - base_address) / (1024.0 * 1024.0));
+
+  // Relocate to a base address that will trigger veneer creation
+  CodeHolder::RelocationSummary summary;
+  err = code.relocate_to_base(base_address, &summary);
+  if (err != Error::kOk)
+    fail("Failed to relocate code", err);
+
+  printf("  Code size reduction: %zu bytes\n", summary.code_size_reduction);
+
+  // Print section information AFTER relocation to see if veneer was created
+  printf("\nSections (after relocation):\n");
+  for (Section* section : code.sections_by_order()) {
+    printf("  [0x%08X %s] {Id=%u Size=%u}\n",
+           uint32_t(section->offset()),
+           section->name(),
+           section->section_id(),
+           uint32_t(section->real_size()));
+  }
+
+  // Verify veneer section was created
+  bool veneer_section_found = false;
+  for (Section* section : code.sections_by_order()) {
+    if (strcmp(section->name(), ".veneer") == 0) {
+      veneer_section_found = true;
+      printf("\n** Veneer section successfully created! **\n");
+      printf("  Offset: 0x%08X\n", uint32_t(section->offset()));
+      printf("  Size: %u bytes\n", uint32_t(section->real_size()));
+      break;
+    }
+  }
+
+  if (!veneer_section_found) {
+    fail("Veneer section was NOT created (test did not exercise veneer path)", Error::kOk);
+  }
+
+  // Copy the flattened code to executable memory (using actual allocated span)
+  allocator.write(span, [&](JitAllocator::Span& span) noexcept -> Error {
+    return code.copy_flattened_data(span.rw(), code_size, CopySectionFlags::kPadTargetBuffer);
+  });
+
+  // Note: We can't actually execute this function as it would branch to an invalid address
+  // This test is mainly to verify that:
+  // 1. The address table section is created
+  // 2. The veneer section is created when needed
+  // 3. The code is properly relocated
+  // 4. No errors occur during the process
+
+  printf("\n** SUCCESS **\n");
+  printf("The veneer mechanism was properly set up.\n");
+  printf("(Note: Function not executed as it would branch to an invalid address)\n");
+
+  allocator.release(span.rx());
+  return 0;
+}
+
+#else
+int main() {
+  printf("!! This test is disabled: ASMJIT_NO_JIT or unsuitable target architecture !!\n\n");
+  return 0;
+}
+#endif // ASMJIT_ARCH_ARM >= ASMJIT_ARCH_ARM64 && !ASMJIT_NO_AARCH64 && !ASMJIT_NO_JIT

--- a/asmjit/arm/a64assembler.cpp
+++ b/asmjit/arm/a64assembler.cpp
@@ -5135,7 +5135,15 @@ EmitOp_Rel:
     if (base_address == Globals::kNoBaseAddress || _section->section_id() != 0) {
       // Create a new RelocEntry as we cannot calculate the offset right now.
       RelocEntry* re;
-      err = _code->new_reloc_entry(Out(re), RelocType::kAbsToRel);
+
+      // Check if this is an unconditional branch (b/bl) with 26-bit encoding.
+      // For these, we use kA64AddressEntry to potentially use branch extension.
+      // Conditional branches cannot use the trampoline.
+      RelocType reloc_type = inst_info->_encoding == InstDB::kEncodingBaseBranchRel
+        ? RelocType::kA64AddressEntry
+        : RelocType::kAbsToRel;
+
+      err = _code->new_reloc_entry(Out(re), reloc_type);
       if (err != Error::kOk) {
         goto Failed;
       }
@@ -5143,7 +5151,16 @@ EmitOp_Rel:
       re->_source_section_id = _section->section_id();
       re->_source_offset = code_offset;
       re->_format = offset_format;
-      re->_payload = rm_rel->as<Imm>().value_as<uint64_t>() + 4u;
+      re->_payload = rm_rel->as<Imm>().value_as<uint64_t>();
+
+      // For kA64AddressEntry, add the target to the address table.
+      if (reloc_type == RelocType::kA64AddressEntry) {
+        err = _code->add_address_to_address_table(re->_payload);
+        if (ASMJIT_UNLIKELY(err != Error::kOk)) {
+          goto Failed;
+        }
+      }
+
       goto EmitOp;
     }
     else {

--- a/asmjit/core/codeholder.h
+++ b/asmjit/core/codeholder.h
@@ -130,7 +130,9 @@ enum class RelocType : uint32_t {
   //! Relocate absolute to relative.
   kAbsToRel = 5,
   //! Relocate absolute to relative or use trampoline.
-  kX64AddressEntry = 6
+  kX64AddressEntry = 6,
+  //! AArch64 address entry for branch instructions with fallback to address table.
+  kA64AddressEntry = 7
 };
 
 //! Type of the \ref Label.
@@ -323,6 +325,64 @@ public:
   //! Returns the `CodeBuffer` used by this section (const).
   [[nodiscard]]
   ASMJIT_INLINE_NODEBUG const CodeBuffer& buffer() const noexcept { return _buffer; }
+
+  //! \}
+};
+
+//! Entry in a veneer table (for AArch64 branch trampolines).
+class VeneerEntry : public ArenaTreeNodeT<VeneerEntry> {
+public:
+  ASMJIT_NONCOPYABLE(VeneerEntry)
+
+  //! \name Members
+  //! \{
+
+  //! Target address.
+  uint64_t _address;
+  //! Offset in veneer section.
+  uint64_t _offset;
+  //! Whether this is a "link" veneer (as in the branch-with-link instruction).
+  bool _is_link;
+
+  //! \}
+
+  //! \name Construction & Destruction
+  //! \{
+
+  ASMJIT_INLINE_NODEBUG explicit VeneerEntry(uint64_t address, bool is_link) noexcept
+    : _address(address),
+      _offset(0xFFFFFFFFFFFFFFFFu),
+      _is_link(is_link) {}
+
+  //! \}
+
+  //! \name Accessors
+  //! \{
+
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG uint64_t address() const noexcept { return _address; }
+
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG uint64_t offset() const noexcept { return _offset; }
+
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG bool is_link() const noexcept { return _is_link; }
+
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG bool has_assigned_offset() const noexcept { return _offset != 0xFFFFFFFFFFFFFFFFu; }
+
+  // Comparison by address and type (both address and is_link must match)
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG bool operator<(const VeneerEntry& other) const noexcept {
+    if (_address != other._address) return _address < other._address;
+    return _is_link < other._is_link;
+  }
+
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG bool operator>(const VeneerEntry& other) const noexcept {
+    if (_address != other._address) return _address > other._address;
+    return _is_link > other._is_link;
+  }
 
   //! \}
 };
@@ -816,6 +876,11 @@ public:
   //! Text section - always one part of a CodeHolder itself.
   Section _text_section;
 
+  //! Pointer to a veneer section for AArch64 (or null if this section doesn't exist).
+  Section* _veneer_section;
+  //! Veneer entries.
+  ArenaTree<VeneerEntry> _veneer_entries;
+
   //! Pointer to an address table section (or null if this section doesn't exist).
   Section* _address_table_section;
   //! Address table entries.
@@ -1022,6 +1087,34 @@ public:
   //! \note Text section is always the first section in \ref CodeHolder::sections() array.
   [[nodiscard]]
   ASMJIT_INLINE_NODEBUG Section* text_section() const noexcept { return _sections[0]; }
+
+  //! Tests whether '.veneer' section exists.
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG bool has_veneer_section() const noexcept { return _veneer_section != nullptr; }
+
+  //! Returns '.veneer' section.
+  //!
+  //! This section is used exclusively by AsmJit to store branch extension
+  //! trampolines for AArch64.
+  //!
+  //! \note This section is created on demand, the returned pointer can be null.
+  [[nodiscard]]
+  ASMJIT_INLINE_NODEBUG Section* veneer_section() const noexcept { return _veneer_section; }
+
+  //! Ensures that '.veneer' section exists (creates it if it doesn't) and
+  //! returns it. Can return `nullptr` on out of memory condition.
+  [[nodiscard]]
+  ASMJIT_API Section* ensure_veneer_section() noexcept;
+
+  //! Used to add a veneer entry to the veneer section.
+  //!
+  //! This implicitly calls `ensure_veneer_section()` and then creates `VeneerEntry` that is inserted to
+  //! `_veneer_entries`. If the address already exists with the same is_link status this operation does nothing as the
+  //! same addresses use the same slot.
+  //!
+  //! This function should be considered internal as it's used by assemblers to insert an absolute address into the
+  //! address table. Inserting address into address table without creating a particular relocation entry makes no sense.
+  ASMJIT_API Error add_veneer_to_veneer_section(Out<VeneerEntry*> veneer, uint64_t address, bool is_link) noexcept;
 
   //! Tests whether '.addrtab' section exists.
   [[nodiscard]]


### PR DESCRIPTION
Closes https://github.com/asmjit/asmjit/issues/499.

When relocating aarch64 code, instead of failing to emit relative jumps when it is not possible, instead add a veneer section to the end of the generated code to function as trampolines. This generally allows the workflow of calling `b`/`bl` with an absolute address without having to worry about it failing to generate if the target is too far.

I'm pretty sure about the code, but was relatively unsure about the tests. @kobalicek please let me know if you have time to review and if you're okay with the tests as they stand or if you would like changes.