### PR TITLE
[bug] Fix BaseAssembler::embed_label

### DIFF
--- a/asmjit/core/assembler.cpp
+++ b/asmjit/core/assembler.cpp
@@ -259,7 +259,7 @@ Error BaseAssembler::embed_label(const Label& label, size_t data_size) {
     return report_error(make_error(Error::kNotInitialized));
   }
 
-  if (ASMJIT_UNLIKELY(is_label_valid(label))) {
+  if (ASMJIT_UNLIKELY(!is_label_valid(label))) {
     return report_error(make_error(Error::kInvalidLabel));
   }
 


### PR DESCRIPTION
v1.17 inverted a label validity check, breaking `BaseAssembler::embed_label`

(Not super happy with the test but there didn't seem to be an obvious place to put it, I felt it needs to execute to be meaningful, not just check for the specific error.)