### PR TITLE
[bug] Fix align() to account for baseAddress

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler_a64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_a64.cpp
@@ -4037,6 +4037,130 @@ static void ASMJIT_NOINLINE test_aarch64_assembler_extra(AssemblerTester<a64::As
   TEST_INSTRUCTION("C167074F", movi(v1.d2(), 0xFE000000FE000000));
 }
 
+static void report_a64_custom_test(AssemblerTester<a64::Assembler>& tester, const char* test_name, bool ok, const char* detail = nullptr) noexcept {
+  tester.count++;
+
+  if (!ok) {
+    printf("  !! %s\n", test_name);
+    if (detail) {
+      printf("     %s\n", detail);
+    }
+    return;
+  }
+
+  if (tester.settings.verbose) {
+    printf("  OK [custom] <- %s\n", test_name);
+  }
+
+  tester.passed++;
+}
+
+static void ASMJIT_NOINLINE test_aarch64_assembler_align_base_address(AssemblerTester<a64::Assembler>& tester) noexcept {
+  using namespace a64;
+
+  auto run = [&](const char* test_name, bool use_base_address, uint64_t base_address, size_t expected_size, const char* expected_hex) noexcept {
+    CodeHolder code;
+    Assembler assembler;
+    String encoded;
+
+    Error err = use_base_address ? code.init(tester.env, base_address) : code.init(tester.env);
+    if (err == Error::kOk) {
+      err = code.attach(&assembler);
+    }
+
+    if (err == Error::kOk) {
+      err = assembler.nop();
+    }
+
+    if (err == Error::kOk) {
+      err = assembler.align(AlignMode::kCode, 16);
+    }
+
+    const Section* text = err == Error::kOk ? code.text_section() : nullptr;
+    if (err == Error::kOk) {
+      err = encoded.append_hex(text->data(), text->buffer_size());
+    }
+
+    bool ok = err == Error::kOk;
+    char detail[256];
+    detail[0] = '\0';
+
+    if (!ok) {
+      snprintf(detail, sizeof(detail), "unexpected error: <%s>", DebugUtils::error_as_string(err));
+    }
+    else if (text->buffer_size() != expected_size) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected %zu bytes, got %zu bytes", expected_size, text->buffer_size());
+    }
+    else if (use_base_address && ((base_address + text->buffer_size()) & 0xFu) != 0) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "buffer ended at 0x%llX instead of a 16-byte boundary",
+               (unsigned long long)(base_address + text->buffer_size()));
+    }
+    else if (encoded != expected_hex) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected [%s], got [%s]", expected_hex, encoded.data());
+    }
+
+    report_a64_custom_test(tester, test_name, ok, detail[0] ? detail : nullptr);
+  };
+
+  auto run_in_section = [&](const char* test_name, uint64_t base_address, uint64_t section_offset, size_t expected_size, const char* expected_hex) noexcept {
+    CodeHolder code;
+    Assembler assembler;
+    Section* section = nullptr;
+    String encoded;
+
+    Error err = code.init(tester.env, base_address);
+    if (err == Error::kOk) {
+      err = code.new_section(Out(section), ".extra");
+    }
+    if (err == Error::kOk) {
+      section->set_offset(section_offset);
+      err = code.attach(&assembler);
+    }
+    if (err == Error::kOk) {
+      err = assembler.section(section);
+    }
+    if (err == Error::kOk) {
+      err = assembler.nop();
+    }
+    if (err == Error::kOk) {
+      err = assembler.align(AlignMode::kCode, 16);
+    }
+    if (err == Error::kOk) {
+      err = encoded.append_hex(section->data(), section->buffer_size());
+    }
+
+    bool ok = err == Error::kOk;
+    char detail[256];
+    detail[0] = '\0';
+
+    if (!ok) {
+      snprintf(detail, sizeof(detail), "unexpected error: <%s>", DebugUtils::error_as_string(err));
+    }
+    else if (section->buffer_size() != expected_size) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected %zu bytes, got %zu bytes", expected_size, section->buffer_size());
+    }
+    else if (((base_address + section_offset + section->buffer_size()) & 0xFu) != 0) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "section ended at 0x%llX instead of a 16-byte boundary",
+               (unsigned long long)(base_address + section_offset + section->buffer_size()));
+    }
+    else if (encoded != expected_hex) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected [%s], got [%s]", expected_hex, encoded.data());
+    }
+
+    report_a64_custom_test(tester, test_name, ok, detail[0] ? detail : nullptr);
+  };
+
+  run("align() keeps legacy code padding without baseAddress", false, 0, 16, "1F2003D51F2003D51F2003D51F2003D5");
+  run("align() accounts for baseAddress", true, 0x1004u, 12, "1F2003D51F2003D51F2003D5");
+  run_in_section("align() accounts for section offset", 0x1000u, 0x8u, 8, "1F2003D51F2003D5");
+}
+
 bool test_aarch64_assembler(const TestSettings& settings) noexcept {
   using namespace a64;
 
@@ -4047,6 +4171,7 @@ bool test_aarch64_assembler(const TestSettings& settings) noexcept {
   test_aarch64_assembler_rel(tester);
   test_aarch64_assembler_simd(tester);
   test_aarch64_assembler_extra(tester);
+  test_aarch64_assembler_align_base_address(tester);
 
   tester.print_summary();
   return tester.did_pass();

--- a/asmjit-testing/tests/asmjit_test_assembler_x86.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x86.cpp
@@ -8445,6 +8445,152 @@ static void ASMJIT_NOINLINE test_x86_assembler_extra(AssemblerTester<x86::Assemb
   TEST_INSTRUCTION("62F2552850F4"                  , vpdpbusd(ymm6, ymm5, ymm4));
 }
 
+static void report_x86_custom_test(AssemblerTester<x86::Assembler>& tester, const char* test_name, bool ok, const char* detail = nullptr) noexcept {
+  tester.count++;
+
+  if (!ok) {
+    printf("  !! %s\n", test_name);
+    if (detail) {
+      printf("     %s\n", detail);
+    }
+    return;
+  }
+
+  if (tester.settings.verbose) {
+    printf("  OK [custom] <- %s\n", test_name); 
+  }
+
+  tester.passed++;
+}
+
+static void ASMJIT_NOINLINE test_x86_assembler_align_base_address(AssemblerTester<x86::Assembler>& tester) noexcept {
+  using namespace x86;
+
+  auto run = [&](const char* test_name, bool use_base_address, uint64_t base_address, bool optimized_align, size_t expected_size, const char* expected_hex) noexcept {
+    CodeHolder code;
+    Assembler assembler;
+    String encoded;
+
+    Error err = use_base_address ? code.init(tester.env, base_address) : code.init(tester.env);
+    if (err == Error::kOk) {
+      err = code.attach(&assembler);
+    }
+
+    if (err == Error::kOk && optimized_align) {
+      assembler.add_encoding_options(EncodingOptions::kOptimizedAlign);
+    }
+
+    if (err == Error::kOk) {
+      err = assembler.nop();
+    }
+
+    if (err == Error::kOk) {
+      err = assembler.align(AlignMode::kCode, 16);
+    }
+
+    const Section* text = err == Error::kOk ? code.text_section() : nullptr;
+    if (err == Error::kOk) {
+      err = encoded.append_hex(text->data(), text->buffer_size());
+    }
+
+    bool ok = err == Error::kOk;
+    char detail[256];
+    detail[0] = '\0';
+
+    if (!ok) {
+      snprintf(detail, sizeof(detail), "unexpected error: <%s>", DebugUtils::error_as_string(err));
+    }
+    else if (text->buffer_size() != expected_size) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected %zu bytes, got %zu bytes", expected_size, text->buffer_size());
+    }
+    else if (use_base_address && ((base_address + text->buffer_size()) & 0xFu) != 0) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "buffer ended at 0x%llX instead of a 16-byte boundary",
+               (unsigned long long)(base_address + text->buffer_size()));
+    }
+    else if (expected_hex) {
+      if (encoded != expected_hex) {
+        ok = false;
+        snprintf(detail, sizeof(detail), "expected [%s], got [%s]", expected_hex, encoded.data());
+      }
+    }
+    else {
+      const uint8_t* data = text->data();
+      for (size_t i = 0; i < text->buffer_size(); i++) {
+        if (data[i] != 0x90u) {
+          ok = false;
+          snprintf(detail, sizeof(detail), "expected 0x90 padding, got [%s]", encoded.data());
+          break;
+        }
+      }
+    }
+
+    report_x86_custom_test(tester, test_name, ok, detail[0] ? detail : nullptr);
+  };
+
+  auto run_in_section = [&](const char* test_name, uint64_t base_address, uint64_t section_offset, size_t expected_size) noexcept {
+    CodeHolder code;
+    Assembler assembler;
+    Section* section = nullptr;
+    String encoded;
+
+    Error err = code.init(tester.env, base_address);
+    if (err == Error::kOk) {
+      err = code.new_section(Out(section), ".extra");
+    }
+    if (err == Error::kOk) {
+      section->set_offset(section_offset);
+      err = code.attach(&assembler);
+    }
+    if (err == Error::kOk) {
+      err = assembler.section(section);
+    }
+    if (err == Error::kOk) {
+      err = assembler.nop();
+    }
+    if (err == Error::kOk) {
+      err = assembler.align(AlignMode::kCode, 16);
+    }
+    if (err == Error::kOk) {
+      err = encoded.append_hex(section->data(), section->buffer_size());
+    }
+
+    bool ok = err == Error::kOk;
+    char detail[256];
+    detail[0] = '\0';
+
+    if (!ok) {
+      snprintf(detail, sizeof(detail), "unexpected error: <%s>", DebugUtils::error_as_string(err));
+    }
+    else if (section->buffer_size() != expected_size) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "expected %zu bytes, got %zu bytes", expected_size, section->buffer_size());
+    }
+    else if (((base_address + section_offset + section->buffer_size()) & 0xFu) != 0) {
+      ok = false;
+      snprintf(detail, sizeof(detail), "section ended at 0x%llX instead of a 16-byte boundary",
+               (unsigned long long)(base_address + section_offset + section->buffer_size()));
+    }
+    else {
+      for (size_t i = 0; i < section->buffer_size(); i++) {
+        if (section->data()[i] != 0x90u) {
+          ok = false;
+          snprintf(detail, sizeof(detail), "expected 0x90 padding in extra section, got [%s]", encoded.data());
+          break;
+        }
+      }
+    }
+
+    report_x86_custom_test(tester, test_name, ok, detail[0] ? detail : nullptr);
+  };
+
+  run("align() keeps legacy code padding without baseAddress", false, 0, false, 16, nullptr);
+  run("align() accounts for baseAddress", true, 0x1003u, false, 13, nullptr);
+  run("optimized align() accounts for baseAddress", true, 0x1005u, true, 11, "90660F1F84000000000090");
+  run_in_section("align() accounts for section offset", 0x1000u, 0x13u, 13);
+}
+
 /*
 // TODO: Failures can be enabled once the assembler always validates.
 static void ASMJIT_NOINLINE test_x86_assembler_failures(AssemblerTester<x86::Assembler>& tester) noexcept {
@@ -8479,6 +8625,7 @@ bool test_x86_assembler(const TestSettings& settings) noexcept {
   test_x86_assembler_avx512(tester);
   test_x86_assembler_avx512_FP16(tester);
   test_x86_assembler_extra(tester);
+  test_x86_assembler_align_base_address(tester);
 
   // test_x86_assembler_failures(tester);
 

--- a/asmjit/arm/a64assembler.cpp
+++ b/asmjit/arm/a64assembler.cpp
@@ -5272,7 +5272,9 @@ Error Assembler::align(AlignMode align_mode, uint32_t alignment) {
     return report_error(make_error(Error::kInvalidArgument));
   }
 
-  uint32_t i = uint32_t(Support::align_up_diff<size_t>(offset(), alignment));
+  uint32_t i = uint32_t(Support::align_up_diff<uint64_t>(
+    EmitterUtils::align_position(uint64_t(offset()), _code->base_address(), _section->offset()),
+    alignment));
   if (i == 0) {
     return Error::kOk;
   }

--- a/asmjit/core/emitterutils_p.h
+++ b/asmjit/core/emitterutils_p.h
@@ -76,6 +76,17 @@ static ASMJIT_INLINE_NODEBUG bool is_absolute_location(uint64_t base_address, ui
   return base_address != Globals::kNoBaseAddress && section_offset != Globals::kNoSectionOffset;
 }
 
+[[nodiscard]]
+static ASMJIT_INLINE_NODEBUG uint64_t align_position(uint64_t code_offset, uint64_t base_address, uint64_t section_offset) noexcept {
+  uint64_t position = code_offset;
+
+  if (is_absolute_location(base_address, section_offset)) {
+    position += base_address + section_offset;
+  }
+
+  return position;
+}
+
 #ifndef ASMJIT_NO_LOGGING
 Error finish_formatted_line(String& sb, const FormatOptions& format_options, const uint8_t* bin_data, size_t bin_size, size_t offset_size, size_t imm_size, const char* comment) noexcept;
 
@@ -104,4 +115,3 @@ Error log_instruction_failed(
 ASMJIT_END_NAMESPACE
 
 #endif // ASMJIT_CORE_EMITTERUTILS_P_H_INCLUDED
-

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -5038,7 +5038,9 @@ Error Assembler::align(AlignMode align_mode, uint32_t alignment) {
   if (ASMJIT_UNLIKELY(!Support::is_power_of_2_up_to(alignment, Globals::kMaxAlignment)))
     return report_error(make_error(Error::kInvalidArgument));
 
-  uint32_t i = uint32_t(Support::align_up_diff<size_t>(offset(), alignment));
+  uint32_t i = uint32_t(Support::align_up_diff<uint64_t>(
+    EmitterUtils::align_position(uint64_t(offset()), _code->base_address(), _section->offset()),
+    alignment));
   if (i > 0) {
     CodeWriter writer(this);
     ASMJIT_PROPAGATE(writer.ensure_space(this, i));


### PR DESCRIPTION
This PR is related to #336 and addresses the missing base address handling in alignment.

Currently, `align()` computes padding based only on the local buffer offset,
which can lead to incorrect alignment when a `baseAddress` or section offset
is involved.

This patch updates the alignment logic to use the effective code position
(i.e. including baseAddress and section offset when available), ensuring
correct padding in all cases.

The scope is intentionally kept minimal and focused on this issue.
Regression tests are included to cover the affected scenarios.