### PR TITLE
[bug] Fixed test_invalid_instruction always reporting failure

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86


### PR DESCRIPTION
`AssemblerTester::test_invalid_instruction` in `asmjit_test_assembler.h` has a second guard `if (err != Error::kOk)` right after an early return on `err == kOk`, so it's always true and every `FAIL_INSTRUCTION(...)` call prints "failed with X, but should have failed with Y" even when the errors match