### PR TITLE
[bug] Fixed push/pop of ES/CS/SS/DS accepted in x64 mode

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -908,6 +908,10 @@ static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembl
   TEST_INSTRUCTION("668F841180000000"              , pop(word_ptr(rcx, rdx, 0, 128)));
   TEST_INSTRUCTION("8F841180000000"                , pop(qword_ptr(rcx, rdx, 0, 128)));
   TEST_INSTRUCTION("0FA1"                          , pop(fs));
+  TEST_INSTRUCTION("0FA9"                          , pop(gs));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , pop(es));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , pop(ss));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , pop(ds));
   TEST_INSTRUCTION("669D"                          , popf());
   TEST_INSTRUCTION("9D"                            , popfq());
   TEST_INSTRUCTION("6651"                          , push(cx));
@@ -916,6 +920,11 @@ static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembl
   TEST_INSTRUCTION("66FFB41180000000"              , push(word_ptr(rcx, rdx, 0, 128)));
   TEST_INSTRUCTION("FFB41180000000"                , push(qword_ptr(rcx, rdx, 0, 128)));
   TEST_INSTRUCTION("0FA0"                          , push(fs));
+  TEST_INSTRUCTION("0FA8"                          , push(gs));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , push(es));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , push(cs));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , push(ss));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , push(ds));
   TEST_INSTRUCTION("669C"                          , pushf());
   TEST_INSTRUCTION("9C"                            , pushfq());
   TEST_INSTRUCTION("66680100"                      , pushw(1));

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -1936,7 +1936,7 @@ CaseX86M_GPB_MulDiv:
       if (isign3 == ENC_OPS1(Reg)) {
         if (o0.is_segment_reg()) {
           uint32_t segment = o0.id();
-          if (ASMJIT_UNLIKELY(segment >= SReg::kIdCount))
+          if (ASMJIT_UNLIKELY(segment >= SReg::kIdCount || (!is_32bit() && segment < SReg::kIdFs)))
             goto InvalidSegment;
 
           opcode = opcode_push_sreg_table[segment];
@@ -1963,7 +1963,7 @@ CaseX86M_GPB_MulDiv:
       if (isign3 == ENC_OPS1(Reg)) {
         if (o0.is_segment_reg()) {
           uint32_t segment = o0.id();
-          if (ASMJIT_UNLIKELY(segment == SReg::kIdCs || segment >= SReg::kIdCount))
+          if (ASMJIT_UNLIKELY(segment == SReg::kIdCs || segment >= SReg::kIdCount || (!is_32bit() && segment < SReg::kIdFs)))
             goto InvalidSegment;
 
           opcode = opcode_pop_sreg_table[segment];


### PR DESCRIPTION
based on #513

push/pop of es, cs, ss, ds aren't valid in 64-bit mode 

the encoder already has dedicated `goto InvalidSegment` guards for segment-reg push/pop in `x86assembler.cpp` - they just check the segment ID range (and `pop cs`), not the mode. adding the mode check seemed like the natural place for it, so the guards now also reject segments below `SReg::kIdFs` when not in 32-bit mode

https://revers.engineering/x86/push.pdf
https://revers.engineering/x86/pop.pdf