### PR TITLE
[bug] Fixed legacy SSE silently truncating xmm16-31 in x64 mode

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -2359,6 +2359,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_mmx_sse(AssemblerTester<x86::Asse
   TEST_INSTRUCTION("660FD4CA"                      , paddq(xmm1, xmm2));
   TEST_INSTRUCTION("660FD48C1A80000000"            , paddq(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("660FD48C1A80000000"            , paddq(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , paddq(xmm16, xmm1));
   TEST_INSTRUCTION("0FECCA"                        , paddsb(mm1, mm2));
   TEST_INSTRUCTION("0FEC8C1A80000000"              , paddsb(mm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("0FEC8C1A80000000"              , paddsb(mm1, qword_ptr(rdx, rbx, 0, 128)));
@@ -2902,6 +2903,8 @@ static void ASMJIT_NOINLINE test_x64_assembler_mmx_sse(AssemblerTester<x86::Asse
   TEST_INSTRUCTION("660FE9CA"                      , psubsw(xmm1, xmm2));
   TEST_INSTRUCTION("660FE98C1A80000000"            , psubsw(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("660FE98C1A80000000"            , psubsw(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , psubsw(xmm21, xmm0));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , psubsw(xmm0, xmm21));
   TEST_INSTRUCTION("0FD8CA"                        , psubusb(mm1, mm2));
   TEST_INSTRUCTION("0FD88C1A80000000"              , psubusb(mm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("0FD88C1A80000000"              , psubusb(mm1, qword_ptr(rdx, rbx, 0, 128)));
@@ -2974,6 +2977,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_mmx_sse(AssemblerTester<x86::Asse
   TEST_INSTRUCTION("660FEFCA"                      , pxor(xmm1, xmm2));
   TEST_INSTRUCTION("660FEF8C1A80000000"            , pxor(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("660FEF8C1A80000000"            , pxor(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , pxor(xmm31, xmm2));
   TEST_INSTRUCTION("0F53CA"                        , rcpps(xmm1, xmm2));
   TEST_INSTRUCTION("0F538C1A80000000"              , rcpps(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("0F538C1A80000000"              , rcpps(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -3963,6 +3963,11 @@ EmitX86OpImplicitMem:
   // ---------------------------------
 
 EmitX86R:
+  // Legacy encodings have no REX.R'|REX.B' bits, so register ids >= 16
+  // (accessible only via EVEX) can't be emitted - reject to avoid silent truncation.
+  if (ASMJIT_UNLIKELY((op_reg | rb_reg) > 0x0Fu))
+    goto InvalidPhysId;
+
   // Mandatory instruction prefix.
   writer.emit_pp(opcode.v);
 
@@ -3998,6 +4003,10 @@ EmitX86RFromM:
   rm_info = mem_info_table[rm_rel->as<Mem>().base_and_index_types()];
   if (ASMJIT_UNLIKELY(rm_rel->as<Mem>().has_offset() || (rm_info & kX86MemInfo_Index)))
     goto InvalidInstruction;
+
+  // Legacy encoding can't reach reg ids >= 16 (EVEX-only).
+  if (ASMJIT_UNLIKELY(op_reg > 0x0Fu))
+    goto InvalidPhysId;
 
   // Emit mandatory instruction prefix.
   writer.emit_pp(opcode.v);
@@ -4039,6 +4048,10 @@ EmitX86M:
   ASMJIT_ASSERT(rm_rel != nullptr);
   ASMJIT_ASSERT(rm_rel->op_type() == OperandType::kMem);
   ASMJIT_ASSERT((opcode & Opcode::kCDSHL_Mask) == 0);
+
+  // Legacy encoding can't reach reg ids >= 16 (EVEX-only).
+  if (ASMJIT_UNLIKELY(op_reg > 0x0Fu))
+    goto InvalidPhysId;
 
   // Emit override prefixes.
   rm_info = mem_info_table[rm_rel->as<Mem>().base_and_index_types()];


### PR DESCRIPTION
based on #513

`xmm16`-`xmm31` only exist under EVEX, legacy SSE has no REX.R'/REX.B' bits, so there's no byte pattern that can reach them