### PR TITLE
[bug] Fixed VEX/XOP instructions producing invalid encodings

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -3182,12 +3182,14 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C4E36D4BCB40"                  , vblendvpd(ymm1, ymm2, ymm3, ymm4));
   TEST_INSTRUCTION("C4E36D4B8C2B8000000060"        , vblendvpd(ymm1, ymm2, ptr(rbx, rbp, 0, 128), ymm6));
   TEST_INSTRUCTION("C4E36D4B8C2B8000000060"        , vblendvpd(ymm1, ymm2, ymmword_ptr(rbx, rbp, 0, 128), ymm6));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vblendvpd(ymm0, ymm0, ymm0, ymm20));
   TEST_INSTRUCTION("C4E3694ACB40"                  , vblendvps(xmm1, xmm2, xmm3, xmm4));
   TEST_INSTRUCTION("C4E3694A8C2B8000000060"        , vblendvps(xmm1, xmm2, ptr(rbx, rbp, 0, 128), xmm6));
   TEST_INSTRUCTION("C4E3694A8C2B8000000060"        , vblendvps(xmm1, xmm2, xmmword_ptr(rbx, rbp, 0, 128), xmm6));
   TEST_INSTRUCTION("C4E36D4ACB40"                  , vblendvps(ymm1, ymm2, ymm3, ymm4));
   TEST_INSTRUCTION("C4E36D4A8C2B8000000060"        , vblendvps(ymm1, ymm2, ptr(rbx, rbp, 0, 128), ymm6));
   TEST_INSTRUCTION("C4E36D4A8C2B8000000060"        , vblendvps(ymm1, ymm2, ymmword_ptr(rbx, rbp, 0, 128), ymm6));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vblendvps(ymm0, ymm0, ymm0, ymm31));
   TEST_INSTRUCTION("C4E27D1A8C1A80000000"          , vbroadcastf128(ymm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D1A8C1A80000000"          , vbroadcastf128(ymm1, xmmword_ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D5A8C1A80000000"          , vbroadcasti128(ymm1, ptr(rdx, rbx, 0, 128)));
@@ -3422,6 +3424,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C5F8AE941180000000"            , vldmxcsr(dword_ptr(rcx, rdx, 0, 128)));
   TEST_INSTRUCTION("C5F9F7CA"                      , vmaskmovdqu(xmm1, xmm2, ptr(rdi)));
   TEST_INSTRUCTION("C5F9F7CA"                      , vmaskmovdqu(xmm1, xmm2, xmmword_ptr(rdi)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , emit(Inst::kIdVmaskmovdqu, xmm20, xmm0));
   TEST_INSTRUCTION("C4E2612FA41180000000"          , vmaskmovpd(ptr(rcx, rdx, 0, 128), xmm3, xmm4));
   TEST_INSTRUCTION("C4E2612FA41180000000"          , vmaskmovpd(xmmword_ptr(rcx, rdx, 0, 128), xmm3, xmm4));
   TEST_INSTRUCTION("C4E2652FA41180000000"          , vmaskmovpd(ptr(rcx, rdx, 0, 128), ymm3, ymm4));
@@ -3777,6 +3780,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C4E36D4CCB40"                  , vpblendvb(ymm1, ymm2, ymm3, ymm4));
   TEST_INSTRUCTION("C4E36D4C8C2B8000000060"        , vpblendvb(ymm1, ymm2, ptr(rbx, rbp, 0, 128), ymm6));
   TEST_INSTRUCTION("C4E36D4C8C2B8000000060"        , vpblendvb(ymm1, ymm2, ymmword_ptr(rbx, rbp, 0, 128), ymm6));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vpblendvb(xmm0, xmm0, xmm0, xmm16));
   TEST_INSTRUCTION("C4E3690ECB01"                  , vpblendw(xmm1, xmm2, xmm3, 1));
   TEST_INSTRUCTION("C4E3690E8C2B8000000001"        , vpblendw(xmm1, xmm2, ptr(rbx, rbp, 0, 128), 1));
   TEST_INSTRUCTION("C4E3690E8C2B8000000001"        , vpblendw(xmm1, xmm2, xmmword_ptr(rbx, rbp, 0, 128), 1));
@@ -4270,6 +4274,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C4E26D0ACB"                    , vpsignd(ymm1, ymm2, ymm3));
   TEST_INSTRUCTION("C4E26D0A8C2B80000000"          , vpsignd(ymm1, ymm2, ptr(rbx, rbp, 0, 128)));
   TEST_INSTRUCTION("C4E26D0A8C2B80000000"          , vpsignd(ymm1, ymm2, ymmword_ptr(rbx, rbp, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vpsignd(xmm20, xmm0, xmm1));
   TEST_INSTRUCTION("C4E26909CB"                    , vpsignw(xmm1, xmm2, xmm3));
   TEST_INSTRUCTION("C4E269098C2B80000000"          , vpsignw(xmm1, xmm2, ptr(rbx, rbp, 0, 128)));
   TEST_INSTRUCTION("C4E269098C2B80000000"          , vpsignw(xmm1, xmm2, xmmword_ptr(rbx, rbp, 0, 128)));
@@ -4428,6 +4433,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C4E27D17CA"                    , vptest(ymm1, ymm2));
   TEST_INSTRUCTION("C4E27D178C1A80000000"          , vptest(ymm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D178C1A80000000"          , vptest(ymm1, ymmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vptest(ymm20, ymm0));
   TEST_INSTRUCTION("C5E968CB"                      , vpunpckhbw(xmm1, xmm2, xmm3));
   TEST_INSTRUCTION("C5E9688C2B80000000"            , vpunpckhbw(xmm1, xmm2, ptr(rbx, rbp, 0, 128)));
   TEST_INSTRUCTION("C5E9688C2B80000000"            , vpunpckhbw(xmm1, xmm2, xmmword_ptr(rbx, rbp, 0, 128)));
@@ -4574,12 +4580,14 @@ static void ASMJIT_NOINLINE test_x64_assembler_avx(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("C4E27D0FCA"                    , vtestpd(ymm1, ymm2));
   TEST_INSTRUCTION("C4E27D0F8C1A80000000"          , vtestpd(ymm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D0F8C1A80000000"          , vtestpd(ymm1, ymmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vtestpd(ymm20, ymm0));
   TEST_INSTRUCTION("C4E2790ECA"                    , vtestps(xmm1, xmm2));
   TEST_INSTRUCTION("C4E2790E8C1A80000000"          , vtestps(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E2790E8C1A80000000"          , vtestps(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D0ECA"                    , vtestps(ymm1, ymm2));
   TEST_INSTRUCTION("C4E27D0E8C1A80000000"          , vtestps(ymm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C4E27D0E8C1A80000000"          , vtestps(ymm1, ymmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vtestps(ymm20, ymm0));
   TEST_INSTRUCTION("C5F92ECA"                      , vucomisd(xmm1, xmm2));
   TEST_INSTRUCTION("C5F92E8C1A80000000"            , vucomisd(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("C5F92E8C1A80000000"            , vucomisd(xmm1, qword_ptr(rdx, rbx, 0, 128)));
@@ -5345,6 +5353,7 @@ static void ASMJIT_NOINLINE test_x64_assembler_xop(AssemblerTester<x86::Assemble
   TEST_INSTRUCTION("8FE978E1CA"                    , vphsubbw(xmm1, xmm2));
   TEST_INSTRUCTION("8FE978E18C1A80000000"          , vphsubbw(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("8FE978E18C1A80000000"          , vphsubbw(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , vphsubbw(xmm30, xmm0));
   TEST_INSTRUCTION("8FE978E3CA"                    , vphsubdq(xmm1, xmm2));
   TEST_INSTRUCTION("8FE978E38C1A80000000"          , vphsubdq(xmm1, ptr(rdx, rbx, 0, 128)));
   TEST_INSTRUCTION("8FE978E38C1A80000000"          , vphsubdq(xmm1, xmmword_ptr(rdx, rbx, 0, 128)));

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -3226,6 +3226,10 @@ CaseVexRvm_R:
       const Operand_& o3 = op_ext[EmitterUtils::kOp3];
       const uint32_t isign4 = isign3 + (uint32_t(o3.op_type()) << 9);
 
+      // 4th operand goes into the is4 byte's upper nibble - only 4 bits of reg id fit.
+      if (ASMJIT_UNLIKELY(o3.is_reg() && o3.id() > 0x0Fu))
+        goto InvalidPhysId;
+
       imm_value = o3.id() << 4;
       imm_size = 1;
 
@@ -3691,6 +3695,7 @@ CaseVexVmi_AfterImm:
       const uint32_t isign4 = isign3 + (uint32_t(o3.op_type()) << 9);
 
       if (isign4 == ENC_OPS4(Reg, Reg, Reg, Reg)) {
+        if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rb_reg = o2.id();
 
@@ -3700,6 +3705,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Reg, Mem)) {
+        if (ASMJIT_UNLIKELY(o2.id() > 0x0Fu)) goto InvalidPhysId;
         opcode.add_w();
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o3;
@@ -3710,6 +3716,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Mem, Reg)) {
+        if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o2;
 
@@ -3734,6 +3741,7 @@ CaseVexVmi_AfterImm:
       imm_size = 1;
 
       if (isign4 == ENC_OPS4(Reg, Reg, Reg, Reg)) {
+        if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rb_reg = o2.id();
 
@@ -3742,6 +3750,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Reg, Mem)) {
+        if (ASMJIT_UNLIKELY(o2.id() > 0x0Fu)) goto InvalidPhysId;
         opcode.add_w();
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o3;
@@ -3751,6 +3760,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Mem, Reg)) {
+        if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o2;
 
@@ -3796,6 +3806,7 @@ CaseVexVmi_AfterImm:
 
         if (!Support::test(options, InstOptions::kX86_ModMR)) {
           // MOD/RM - Encoding preferred by LLVM.
+          if (ASMJIT_UNLIKELY(o2.id() > 0x0Fu)) goto InvalidPhysId;
           opcode.add_w();
           rb_reg = o3.id();
 
@@ -3805,6 +3816,7 @@ CaseVexVmi_AfterImm:
         }
         else {
           // MOD/MR - Alternative encoding.
+          if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
           rb_reg = o2.id();
 
           imm_value = o3.id() << 4;
@@ -3814,6 +3826,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Reg, Mem)) {
+        if (ASMJIT_UNLIKELY(o2.id() > 0x0Fu)) goto InvalidPhysId;
         opcode.add_w();
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o3;
@@ -3824,6 +3837,7 @@ CaseVexVmi_AfterImm:
       }
 
       if (isign4 == ENC_OPS4(Reg, Reg, Mem, Reg)) {
+        if (ASMJIT_UNLIKELY(o3.id() > 0x0Fu)) goto InvalidPhysId;
         op_reg = pack_reg_and_vvvvv(o0.id(), o1.id());
         rm_rel = &o2;
 
@@ -4581,6 +4595,11 @@ EmitVexEvexR:
       }
     }
 
+    // If EVEX-forcing bits are present (high reg id, {k}, {z}, {sae}, {er}) on a VEX-only mnemonic,
+    // the user is reaching for something this encoding can't express - reject instead of ghost-promoting to EVEX.
+    if (ASMJIT_UNLIKELY((x & kEvexBits) != 0 && !common_info->is_evex()))
+      goto InvalidPhysId;
+
     // Check if EVEX is required by checking bits in `x` :     [........|xx.x.xxx|x......x|.x.x....].
     if (x & kEvexBits) {
       uint32_t y = ((x << 4) & 0x00080000u) |               // [........|...bV...|........|........].
@@ -4694,6 +4713,11 @@ EmitVexEvexM:
         x |= kEvexForce;
       }
     }
+
+    // If EVEX-forcing bits are present (high reg id, {k}, {z}, {sae}, {er}) on a VEX-only mnemonic,
+    // the user is reaching for something this encoding can't express - reject instead of ghost-promoting to EVEX.
+    if (ASMJIT_UNLIKELY((x & kEvexBits) != 0 && !common_info->is_evex()))
+      goto InvalidPhysId;
 
     // Check if EVEX is required by checking bits in `x` :     [@.......|xx.xxxxx|x......x|...x....].
     if (x & kEvexBits) {


### PR DESCRIPTION
...for high register ids

based on #513

fix 1 - right before the `if (x & kEvexBits)` decision, one extra check: if evex-forcing bits are set on an instruction that doesn't have an EVEX form, reject with `kInvalidPhysId` instead of emitting vex-only insn as evex

fix 2 - at every `imm_value [|=] oN.id() << 4` site guard with `if (oN.id() > 0x0Fu) goto InvalidPhysId;`