### PR TITLE
[bug] Fixed accepting illegal MOV CS and MOV Sreg emitting REX.W

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -739,7 +739,13 @@ static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembl
   TEST_INSTRUCTION("899C1180000000"                , mov(ptr(rcx, rdx, 0, 128), ebx));
   TEST_INSTRUCTION("899C1180000000"                , mov(dword_ptr(rcx, rdx, 0, 128), ebx));
   TEST_INSTRUCTION("4889D1"                        , mov(rcx, rdx));
-  TEST_INSTRUCTION("488EE2"                        , mov(fs, rdx));
+  TEST_INSTRUCTION("8EE2"                          , mov(fs, rdx));
+  TEST_INSTRUCTION("418EE7"                        , mov(fs, r15));
+  TEST_INSTRUCTION("8EE8"                          , mov(gs, rax));
+  TEST_INSTRUCTION("8EDB"                          , mov(ds, rbx));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , mov(cs, ax));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , mov(cs, bx));
+  FAIL_INSTRUCTION(Error::kInvalidSegment          , mov(cs, ptr(rax)));
   TEST_INSTRUCTION("0F22CA"                        , mov(cr1, rdx));
   TEST_INSTRUCTION("0F23CA"                        , mov(dr1, rdx));
   TEST_INSTRUCTION("48899C1180000000"              , mov(ptr(rcx, rdx, 0, 128), rbx));

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -1630,8 +1630,13 @@ CaseX86M_GPB_MulDiv:
 
           // SReg <- GP
           if (o0.is_segment_reg()) {
+            // MOV Sreg, r/m16 is always 16-bit - the only prefix that matters is 66h for word size.
+            // A 32- or 64-bit GP source is accepted as a convenience, but no REX.W should be emitted.
+            if (ASMJIT_UNLIKELY(o0.id() == SReg::kIdCs))
+              goto InvalidSegment;
             opcode = 0x8E;
-            opcode.add_prefix_by_size(o1.x86_rm_size());
+            if (o1.x86_rm_size() == 2)
+              opcode |= Opcode::kPP_66;
             op_reg--;
             goto EmitX86R;
           }
@@ -1664,8 +1669,11 @@ CaseX86M_GPB_MulDiv:
 
         // SReg <- Mem
         if (o0.is_segment_reg()) {
+          if (ASMJIT_UNLIKELY(o0.id() == SReg::kIdCs))
+            goto InvalidSegment;
           opcode = 0x8E;
-          opcode.add_prefix_by_size(o1.x86_rm_size());
+          if (o1.x86_rm_size() == 2)
+            opcode |= Opcode::kPP_66;
           op_reg--;
           goto EmitX86M;
         }


### PR DESCRIPTION
based on https://github.com/asmjit/asmjit/pull/513

1. `MOV CS, r/m` is not a legal instruction

2. while touching this dispatch, also dropped the bogus REX.W that gets emitted when the user passes a 64-bit GP source to `MOV Sreg` (opcode 8E /r is always 16-bit per sdm; REX.W is wasted). not a correctness issue - the cpu ignores the prefix, but its more compact without the prefix

https://revers.engineering/x86/mov.pdf