### PR TITLE
[bug] Fixed MOV r, CR/DR accepting reserved register ids

### DIFF
--- a/asmjit-testing/tests/asmjit_test_assembler.h
+++ b/asmjit-testing/tests/asmjit_test_assembler.h
@@ -91,7 +91,7 @@ public:
       return false;
     }
 
-    if (err != asmjit::Error::kOk) {
+    if (err != expected_error) {
       printf("  !! %s failed with <%s>, but should have failed with <%s>\n", s, asmjit::DebugUtils::error_as_string(err), asmjit::DebugUtils::error_as_string(expected_error));
       prepare();
       return false;

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -740,8 +740,17 @@ static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembl
   TEST_INSTRUCTION("899C1180000000"                , mov(dword_ptr(rcx, rdx, 0, 128), ebx));
   TEST_INSTRUCTION("4889D1"                        , mov(rcx, rdx));
   TEST_INSTRUCTION("488EE2"                        , mov(fs, rdx));
-  TEST_INSTRUCTION("0F22CA"                        , mov(cr1, rdx));
+  TEST_INSTRUCTION("0F22DA"                        , mov(cr3, rdx));
   TEST_INSTRUCTION("0F23CA"                        , mov(dr1, rdx));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(cr1,  rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(cr5,  rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(cr7,  rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(cr9,  rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(cr15, rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(dr8,  rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(dr15, rax));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(rax, cr1));
+  FAIL_INSTRUCTION(Error::kInvalidPhysId           , mov(rax, dr8));
   TEST_INSTRUCTION("48899C1180000000"              , mov(ptr(rcx, rdx, 0, 128), rbx));
   TEST_INSTRUCTION("48899C1180000000"              , mov(qword_ptr(rcx, rdx, 0, 128), rbx));
   TEST_INSTRUCTION("B101"                          , mov(cl, 1));

--- a/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x64.cpp
@@ -19,6 +19,9 @@ using namespace asmjit;
 #define TEST_INSTRUCTION(OPCODE, ...) \
   tester.test_valid_instruction(#__VA_ARGS__, OPCODE, tester.assembler.__VA_ARGS__)
 
+#define FAIL_INSTRUCTION(ExpectedError, ...) \
+  tester.test_invalid_instruction(#__VA_ARGS__, ExpectedError, tester.assembler.__VA_ARGS__)
+
 static void ASMJIT_NOINLINE test_x64_assembler_base(AssemblerTester<x86::Assembler>& tester) noexcept {
   using namespace x86;
 
@@ -18068,6 +18071,7 @@ bool test_x64_assembler(const TestSettings& settings) noexcept {
   return tester.did_pass();
 }
 
+#undef FAIL_INSTRUCTION
 #undef TEST_INSTRUCTION
 
 #endif // !ASMJIT_NO_X86

--- a/asmjit-testing/tests/asmjit_test_assembler_x86.cpp
+++ b/asmjit-testing/tests/asmjit_test_assembler_x86.cpp
@@ -596,7 +596,7 @@ static void ASMJIT_NOINLINE test_x86_assembler_base(AssemblerTester<x86::Assembl
   TEST_INSTRUCTION("668EA41A80000000"              , mov(fs, word_ptr(edx, ebx, 0, 128)));
   TEST_INSTRUCTION("0F20D1"                        , mov(ecx, cr2));
   TEST_INSTRUCTION("0F21D1"                        , mov(ecx, dr2));
-  TEST_INSTRUCTION("0F22CA"                        , mov(cr1, edx));
+  TEST_INSTRUCTION("0F22DA"                        , mov(cr3, edx));
   TEST_INSTRUCTION("0F23CA"                        , mov(dr1, edx));
   TEST_INSTRUCTION("A4"                            , movs(byte_ptr(edi), byte_ptr(esi)));
   TEST_INSTRUCTION("66A5"                          , movs(word_ptr(edi), word_ptr(esi)));

--- a/asmjit/x86/x86assembler.cpp
+++ b/asmjit/x86/x86assembler.cpp
@@ -1604,6 +1604,10 @@ CaseX86M_GPB_MulDiv:
 
           // GP <- CReg
           if (o1.is_control_reg()) {
+            // Valid CRs per Intel SDM are only CR0, CR2, CR3, CR4, CR8.
+            // Others are reserved and produce #UD.
+            if (ASMJIT_UNLIKELY(op_reg >= 16u || ((1u << op_reg) & 0x0000011Du) == 0u))
+              goto InvalidPhysId;
             opcode = Opcode::k000F00 | 0x20;
 
             // Use `LOCK MOV` in 32-bit mode if CR8+ register is accessed (AMD extension).
@@ -1616,6 +1620,9 @@ CaseX86M_GPB_MulDiv:
 
           // GP <- DReg
           if (o1.is_debug_reg()) {
+            // Only DR0-DR7 are available per Intel SDM.
+            if (ASMJIT_UNLIKELY(op_reg > 7u))
+              goto InvalidPhysId;
             opcode = Opcode::k000F00 | 0x21;
             goto EmitX86R;
           }
@@ -1638,6 +1645,8 @@ CaseX86M_GPB_MulDiv:
 
           // CReg <- GP
           if (o0.is_control_reg()) {
+            if (ASMJIT_UNLIKELY(op_reg >= 16u || ((1u << op_reg) & 0x0000011Du) == 0u))
+              goto InvalidPhysId;
             opcode = Opcode::k000F00 | 0x22;
 
             // Use `LOCK MOV` in 32-bit mode if CR8+ register is accessed (AMD extension).
@@ -1650,6 +1659,8 @@ CaseX86M_GPB_MulDiv:
 
           // DReg <- GP
           if (o0.is_debug_reg()) {
+            if (ASMJIT_UNLIKELY(op_reg > 7u))
+              goto InvalidPhysId;
             opcode = Opcode::k000F00 | 0x23;
             goto EmitX86R;
           }


### PR DESCRIPTION
based on #513 

1. #UD would happen when an attempt is made to access CR1, CR5, CR6, CR7, or CR9-CR15
2. encodings for accessing DR8-DR15 are not defined 

https://revers.engineering/x86/movcr.pdf
https://revers.engineering/x86/movdr.pdf
