### PR TITLE
virtmem: include OSCacheControl.h on all Apple platforms

### DIFF
--- a/asmjit/core/virtmem.cpp
+++ b/asmjit/core/virtmem.cpp
@@ -63,8 +63,11 @@
     #include <TargetConditionals.h>
     #if TARGET_OS_OSX
       #include <sys/utsname.h>
-      #include <libkern/OSCacheControl.h> // sys_icache_invalidate().
     #endif
+    // sys_icache_invalidate() is available on all Apple platforms
+    // (iOS, Mac Catalyst, macOS).  Without this include, Catalyst
+    // builds fail with "undeclared identifier" at the call site.
+    #include <libkern/OSCacheControl.h>
     // Older SDK doesn't define `MAP_JIT`.
     #ifndef MAP_JIT
       #define MAP_JIT 0x800


### PR DESCRIPTION
sys_icache_invalidate() is called by VirtMem::flushInstructionCache on every Apple SDK (iOS, Mac Catalyst, tvOS, watchOS, macOS), but the #include <libkern/OSCacheControl.h> is currently guarded by TARGET_OS_OSX. On Mac Catalyst (TARGET_OS_OSX=0, TARGET_OS_MACCATALYST=1) this fails to compile with "undeclared identifier sys_icache_invalidate".

This patch moves the include out of the TARGET_OS_OSX guard. The header is available on every Apple SDK so the unconditional include is safe.

Verified on Mac Catalyst arm64 (Xcode 26 / macOS 26.5 SDK) — fixes the build break.