### PR TITLE
[bug] Fix emit_3i() destroying src2 when dst aliases it (x86)

### DIFF
--- a/asmjit-testing/tests/asmjit_test_unicompiler.cpp
+++ b/asmjit-testing/tests/asmjit_test_unicompiler.cpp
@@ -931,7 +931,24 @@ static ASMJIT_NOINLINE void test_rr_ops(JitContext& ctx) {
 // ujit::UniCompiler - Tests - RRR Operations - Functions
 // ======================================================
 
-static TestRRRFunc create_func_rrr(JitContext& ctx, UniOpRRR op) {
+// Which source register the destination aliases. emit_3i() has dedicated paths
+// for `dst == src1` and `dst == src2`, so each test vector is run through all
+// three shapes - a destination that aliases nothing only covers one of them.
+enum class RRRAlias : uint32_t {
+  kNone = 0,
+  kDstIsSrc1,
+  kDstIsSrc2
+};
+
+static const char* rrr_alias_name(RRRAlias alias) {
+  switch (alias) {
+    case RRRAlias::kDstIsSrc1: return "dst == src1";
+    case RRRAlias::kDstIsSrc2: return "dst == src2";
+    default: return "dst is distinct";
+  }
+}
+
+static TestRRRFunc create_func_rrr(JitContext& ctx, UniOpRRR op, RRRAlias alias) {
   ctx.prepare();
 
   UniCompiler uc(&ctx.cc, ctx.features, ctx.cpu_hints);
@@ -942,10 +959,13 @@ static TestRRRFunc create_func_rrr(JitContext& ctx, UniOpRRR op) {
 
   Gp a = uc.new_gp32("a");
   Gp b = uc.new_gp32("b");
-  Gp result = uc.new_gp32("result");
 
   node->set_arg(0, a);
   node->set_arg(1, b);
+
+  Gp result = alias == RRRAlias::kDstIsSrc1 ? a
+            : alias == RRRAlias::kDstIsSrc2 ? b
+            : uc.new_gp32("result");
 
   uc.emit_3i(op, result, a, b);
   uc.ret(result);
@@ -954,7 +974,7 @@ static TestRRRFunc create_func_rrr(JitContext& ctx, UniOpRRR op) {
   return ctx.finish<TestRRRFunc>();
 }
 
-static TestRRIFunc create_func_rri(JitContext& ctx, UniOpRRR op, Imm bImm) {
+static TestRRIFunc create_func_rri(JitContext& ctx, UniOpRRR op, Imm bImm, RRRAlias alias) {
   ctx.prepare();
 
   UniCompiler uc(&ctx.cc, ctx.features, ctx.cpu_hints);
@@ -964,9 +984,10 @@ static TestRRIFunc create_func_rri(JitContext& ctx, UniOpRRR op, Imm bImm) {
   EXPECT_NOT_NULL(node);
 
   Gp a = uc.new_gp32("a");
-  Gp result = uc.new_gp32("result");
 
   node->set_arg(0, a);
+
+  Gp result = alias == RRRAlias::kDstIsSrc1 ? a : uc.new_gp32("result");
 
   uc.emit_3i(op, result, a, bImm);
   uc.ret(result);
@@ -979,37 +1000,49 @@ static TestRRIFunc create_func_rri(JitContext& ctx, UniOpRRR op, Imm bImm) {
 // ===================================================
 
 static ASMJIT_NOINLINE void test_rrr_op(JitContext& ctx, UniOpRRR op, uint32_t a, uint32_t b, uint32_t expected) {
-  TestRRRFunc fn_rrr = create_func_rrr(ctx, op);
-  uint32_t observed_rrr = fn_rrr(a, b);
-  EXPECT_EQ(observed_rrr, expected)
-    .message("Operation failed (RRR):\n"
-            "      Input #1: %d\n"
-            "      Input #2: %d\n"
-            "      Expected: %d\n"
-            "      Observed: %d\n"
-            "Assembly:\n%s",
-            a,
-            b,
-            uint32_t(expected),
-            observed_rrr,
-            ctx.logger_content());
+  static constexpr RRRAlias rrr_aliases[3] = {
+    RRRAlias::kNone,
+    RRRAlias::kDstIsSrc1,
+    RRRAlias::kDstIsSrc2
+  };
 
-  TestRRIFunc fn_rri = create_func_rri(ctx, op, Imm(b));
-  uint32_t observed_rri = fn_rri(a);
-  EXPECT_EQ(observed_rri, expected)
-    .message("Operation failed (RRI):\n"
-            "      Input #1: %d\n"
-            "      Input #2: %d\n"
-            "      Expected: %d\n"
-            "      Observed: %d\n"
-            "Assembly:\n%s",
-            a,
-            b,
-            uint32_t(expected),
-            observed_rri,
-            ctx.logger_content());
+  for (RRRAlias alias : rrr_aliases) {
+    TestRRRFunc fn_rrr = create_func_rrr(ctx, op, alias);
+    uint32_t observed_rrr = fn_rrr(a, b);
+    EXPECT_EQ(observed_rrr, expected)
+      .message("Operation failed (RRR, %s):\n"
+              "      Input #1: %d\n"
+              "      Input #2: %d\n"
+              "      Expected: %d\n"
+              "      Observed: %d\n"
+              "Assembly:\n%s",
+              rrr_alias_name(alias),
+              a,
+              b,
+              uint32_t(expected),
+              observed_rrr,
+              ctx.logger_content());
+    ctx.rt.reset();
+  }
 
-  ctx.rt.reset();
+  for (RRRAlias alias : { RRRAlias::kNone, RRRAlias::kDstIsSrc1 }) {
+    TestRRIFunc fn_rri = create_func_rri(ctx, op, Imm(b), alias);
+    uint32_t observed_rri = fn_rri(a);
+    EXPECT_EQ(observed_rri, expected)
+      .message("Operation failed (RRI, %s):\n"
+              "      Input #1: %d\n"
+              "      Input #2: %d\n"
+              "      Expected: %d\n"
+              "      Observed: %d\n"
+              "Assembly:\n%s",
+              rrr_alias_name(alias),
+              a,
+              b,
+              uint32_t(expected),
+              observed_rri,
+              ctx.logger_content());
+    ctx.rt.reset();
+  }
 }
 
 static ASMJIT_NOINLINE void test_rrr_ops(JitContext& ctx) {

--- a/asmjit/ujit/unicompiler_x86.cpp
+++ b/asmjit/ujit/unicompiler_x86.cpp
@@ -1258,10 +1258,21 @@ void UniCompiler::emit_3i(UniOpRRR op, const Gp& dst, const Operand_& src1_, con
       }
 
       case UniOpRRR::kSBound: {
-        cc->xor_(dst, dst);
-        cc->cmp(a, b);
-        cc->cmovbe(dst, a);
-        cc->cmovg(dst, b);
+        if (dst_is_a) {
+          // Zeroing dst would destroy `a`, so start from `a` and clamp in place.
+          Gp zero = new_similar_reg(dst, "@zero");
+
+          cc->xor_(zero, zero);
+          cc->cmp(dst, b);
+          cc->cmova(dst, zero);
+          cc->cmovg(dst, b);
+        }
+        else {
+          cc->xor_(dst, dst);
+          cc->cmp(a, b);
+          cc->cmovbe(dst, a);
+          cc->cmovg(dst, b);
+        }
         return;
       }
 
@@ -1294,9 +1305,16 @@ void UniCompiler::emit_3i(UniOpRRR op, const Gp& dst, const Operand_& src1_, con
         ASMJIT_ASSERT(dst.size() == b.size());
 
         InstId inst_id = legacy_logical_inst_table[size_t(op) - size_t(UniOpRRR::kAnd)];
-        if (!dst_is_a)
-          cc->mov(dst, a);
-        cc->emit(inst_id, dst, b);
+        if (dst_is_b) {
+          // Moving `a` into `dst` first would destroy `b` - these are commutative,
+          // so `dst = dst op a` is emitted instead.
+          cc->emit(inst_id, dst, a);
+        }
+        else {
+          if (!dst_is_a)
+            cc->mov(dst, a);
+          cc->emit(inst_id, dst, b);
+        }
         return;
       }
 
@@ -1453,10 +1471,11 @@ void UniCompiler::emit_3i(UniOpRRR op, const Gp& dst, const Operand_& src1_, con
           return;
         }
         else if (dst_is_b) {
+          // Shifts are not commutative, so the count has to be preserved in a
+          // temporary BEFORE `a` is moved into `dst`, which is where it lives.
           Gp tmp = new_gp32("@tmp");
-          if (!dst_is_a)
-            cc->mov(dst, a);
           cc->mov(tmp, b.r32());
+          cc->mov(dst, a);
           cc->emit(legacy_inst_id, dst, tmp.r8());
         }
         else {
@@ -1467,13 +1486,25 @@ void UniCompiler::emit_3i(UniOpRRR op, const Gp& dst, const Operand_& src1_, con
       }
 
       case UniOpRRR::kSBound: {
-        if (dst.id() == a.id()) {
+        if (dst_is_a) {
+          // Zeroing dst would destroy `a`, so start from `a` and clamp in place.
           Gp zero = new_similar_reg(dst, "@zero");
 
           cc->xor_(zero, zero);
           cc->cmp(dst, b);
           cc->cmova(dst, zero);
           cc->cmovg(dst, b);
+        }
+        else if (dst_is_b) {
+          // Zeroing dst would destroy `b`, which is read twice, so the result is
+          // accumulated in a temporary and moved into dst at the end.
+          Gp acc = new_similar_reg(dst, "@acc");
+
+          cc->xor_(acc, acc);
+          cc->cmp(a, dst);
+          cc->cmovbe(acc, a);
+          cc->cmovg(acc, dst);
+          cc->mov(dst, acc);
         }
         else {
           cc->xor_(dst, dst);


### PR DESCRIPTION
The Reg,Reg,Reg paths for AND/OR/XOR, the non-BMI2 shift fallback and SBound all wrote into dst before they had finished reading src2, so `dst = src1 op src2` silently produced wrong code whenever dst was the same virtual register as src2:

  - AND/OR/XOR emitted `mov dst, src1` first, so the following `and dst, src2` read src1 rather than src2. These are commutative, so `dst = dst op src1` is emitted instead.
  - The legacy shift fallback moved src1 into dst before saving the shift count out of dst, losing the count. Shifts are not commutative, so the count is now copied to a temporary first.
  - SBound zeroed dst before comparing against it. The dst == src2 case now accumulates into a temporary; the Reg,Reg,Mem form had the same problem for dst == src1 and now clamps in place, matching the Reg,Reg,Reg form.

None of these raised an error, they just emitted wrong code.

test_rrr_op() only ever used a destination distinct from both sources, which is why none of this was caught. It now runs every RRR vector through dst-distinct, dst == src1 and dst == src2, and every RRI vector through dst-distinct and dst == src1. Reverting any of the three fixes above makes the suite fail.